### PR TITLE
Add GitHub Actions for Linting and Cargo Tests

### DIFF
--- a/.github/workflows/cargo-test.yml
+++ b/.github/workflows/cargo-test.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Build
       run: cargo build --verbose
-      working-directory: rust/
+      working-directory: rust/runtime/
     - name: Run tests
       run: cargo test --verbose
-      working-directory: rust/
+      working-directory: rust/runtime/

--- a/.github/workflows/check-and-lint.yml
+++ b/.github/workflows/check-and-lint.yml
@@ -12,9 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - run: rustup component add clippy
-        working-directory: rust/
       - uses: actions-rs/clippy-check@v1
-        working-directory: rust/
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features
+          args: --all-features --manifest-path rust/runtime/Cargo.toml


### PR DESCRIPTION
- Referred `illinoisData/airindex` repo to add linting and cargo tests.
- Currently, triggers on changes to `rust/` folder or the `.github/workflows/*` folder.