### PR TITLE
An example script using a different memory allocator

### DIFF
--- a/rust/runtime/Cargo.toml
+++ b/rust/runtime/Cargo.toml
@@ -22,6 +22,11 @@ rustc-hash = "1.1.0"
 simple-error = "0.2.3"
 structopt = "0.3.26"
 uuid = { version = "0.8", features = ["v4"] }
+jemallocator = "0.3.2"
+
+[profile.release]
+lto = "fat"
+codegen-units = 1
 
 [dev-dependencies]
 ctor = "0.1.21"

--- a/rust/runtime/examples/tpch/main.rs
+++ b/rust/runtime/examples/tpch/main.rs
@@ -1,3 +1,6 @@
+#[global_allocator]
+static GLOBAL: jemallocator::Jemalloc = jemallocator::Jemalloc;
+
 use crate::utils::TableInput;
 
 extern crate runtime;


### PR DESCRIPTION
Also, set the following env variable for further optimization.
```
export RUSTFLAGS='-C target-cpu=native'
```

Based on this page: https://deterministic.space/high-performance-rust.html