### PR TITLE
Save intermediate query results and durations for accuracy plot

### DIFF
--- a/deepola/wake/Cargo.toml
+++ b/deepola/wake/Cargo.toml
@@ -27,6 +27,8 @@ jemallocator = "0.3.2"
 polars = "0.23.2"
 glob = "0.3.0"
 alphanumeric-sort = "1.4.4"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0.85"
 
 [dev-dependencies]
 ctor = "0.1.21"


### PR DESCRIPTION
Currently `run_query` only saves the last df query result. We would want intermediate results to measure accuracy over partition/time. These changes are
1. Save possibly multiple intermediate dfs into multiple CSVs
2. Save durations for these results into JSON (for parsing/inspecting convenience)

Add some error handling too, e.g. the panic message is more clear when `outputs` directory doesn't exist.