### PR TITLE
Add temporary group count column and apply scaler on 12 TPC-H aggregates

### DIFF
--- a/deepola/wake/examples/tpch_polars/q1.rs
+++ b/deepola/wake/examples/tpch_polars/q1.rs
@@ -111,7 +111,8 @@ pub fn query(
         .accumulator(sum_accumulator)
         .build();
 
-    let scaler_node = AggregateScaler::new_growing("l_orderkey_count".into())
+    let scaler_node = AggregateScaler::new_growing()
+        .count_column("l_orderkey_count".into())
         .scale_count("l_orderkey_count".into())
         .scale_sum("l_quantity_sum".into())
         .scale_sum("l_extendedprice_sum".into())

--- a/deepola/wake/examples/tpch_polars/q12.rs
+++ b/deepola/wake/examples/tpch_polars/q12.rs
@@ -5,6 +5,7 @@ use itertools::Itertools;
 use polars::prelude::{DataFrame, NamedFrom, Series};
 use polars::series::ChunkCompare;
 use wake::graph::*;
+use wake::inference::AggregateScaler;
 use wake::polars_operations::*;
 
 use std::collections::HashMap;
@@ -118,10 +119,16 @@ pub fn query(
         .set_aggregates(vec![
             ("high_line".into(), vec!["sum".into()]),
             ("low_line".into(), vec!["sum".into()]),
-        ]);
+        ])
+        .set_add_count_column(true);
     let groupby_node = AccumulatorNode::<DataFrame, AggAccumulator>::new()
         .accumulator(agg_accumulator)
         .build();
+    let scaler_node = AggregateScaler::new_growing()
+        .remove_count_column()  // Remove added group count column
+        .scale_sum("high_line_sum".into())
+        .scale_sum("low_line_sum".into())
+        .into_node();
 
     let select_node = AppenderNode::<DataFrame, MapAppender>::new()
         .appender(MapAppender::new(Box::new(|df: &DataFrame| {
@@ -135,7 +142,8 @@ pub fn query(
     lo_merge_join_node.subscribe_to_node(&orders_csvreader_node, 1);
     expression_node.subscribe_to_node(&lo_merge_join_node, 0);
     groupby_node.subscribe_to_node(&expression_node, 0);
-    select_node.subscribe_to_node(&groupby_node, 0);
+    scaler_node.subscribe_to_node(&groupby_node, 0);
+    select_node.subscribe_to_node(&scaler_node, 0);
 
     // Output reader subscribe to output node.
     output_reader.subscribe_to_node(&select_node, 0);
@@ -148,6 +156,7 @@ pub fn query(
     service.add(lo_merge_join_node);
     service.add(expression_node);
     service.add(groupby_node);
+    service.add(scaler_node);
     service.add(select_node);
     service
 }

--- a/deepola/wake/examples/tpch_polars/q17.rs
+++ b/deepola/wake/examples/tpch_polars/q17.rs
@@ -5,6 +5,7 @@ use polars::prelude::NamedFrom;
 use polars::series::ChunkCompare;
 use polars::series::Series;
 use wake::graph::*;
+use wake::inference::AggregateScaler;
 use wake::polars_operations::*;
 
 use std::collections::HashMap;
@@ -110,10 +111,16 @@ pub fn query(
 
     // AGGREGATE Node
     let mut agg_accumulator = AggAccumulator::new();
-    agg_accumulator.set_aggregates(vec![("l_extendedprice".into(), vec!["sum".into()])]);
+    agg_accumulator
+        .set_aggregates(vec![("l_extendedprice".into(), vec!["sum".into()])])
+        .set_add_count_column(true);
     let final_groupby_node = AccumulatorNode::<DataFrame, AggAccumulator>::new()
         .accumulator(agg_accumulator)
         .build();
+    let scaler_node = AggregateScaler::new_growing()
+        .remove_count_column()  // Remove added group count column
+        .scale_sum("l_extendedprice_sum".into())
+        .into_node();
 
     // SELECT Node
     let select_node = AppenderNode::<DataFrame, MapAppender>::new()
@@ -136,7 +143,8 @@ pub fn query(
     ll_hash_join_node.subscribe_to_node(&lp_hash_join_node, 1);
     lineitem_where_node.subscribe_to_node(&ll_hash_join_node, 0);
     final_groupby_node.subscribe_to_node(&lineitem_where_node, 0);
-    select_node.subscribe_to_node(&final_groupby_node, 0);
+    scaler_node.subscribe_to_node(&final_groupby_node, 0);
+    select_node.subscribe_to_node(&scaler_node, 0);
 
     // Output reader subscribe to output node.
     output_reader.subscribe_to_node(&select_node, 0);
@@ -152,6 +160,7 @@ pub fn query(
     service.add(ll_hash_join_node);
     service.add(lineitem_where_node);
     service.add(final_groupby_node);
+    service.add(scaler_node);
     service.add(select_node);
     service
 }

--- a/deepola/wake/examples/tpch_polars/q19.rs
+++ b/deepola/wake/examples/tpch_polars/q19.rs
@@ -6,6 +6,7 @@ use polars::prelude::NamedFrom;
 use polars::series::ChunkCompare;
 use polars::series::Series;
 use wake::graph::*;
+use wake::inference::AggregateScaler;
 use wake::polars_operations::*;
 
 use std::collections::HashMap;
@@ -168,10 +169,16 @@ pub fn query(
 
     // GROUP BY Node
     let mut sum_accumulator = AggAccumulator::new();
-    sum_accumulator.set_aggregates(vec![("disc_price".into(), vec!["sum".into()])]);
+    sum_accumulator
+        .set_aggregates(vec![("disc_price".into(), vec!["sum".into()])])
+        .set_add_count_column(true);
     let groupby_node = AccumulatorNode::<DataFrame, AggAccumulator>::new()
         .accumulator(sum_accumulator)
         .build();
+    let scaler_node = AggregateScaler::new_growing()
+        .remove_count_column()  // Remove added group count column
+        .scale_sum("disc_price_sum".into())
+        .into_node();
 
     // Connect nodes with subscription
     hash_join_node.subscribe_to_node(&lineitem_csvreader_node, 0); // Left Node
@@ -179,12 +186,14 @@ pub fn query(
     where_node.subscribe_to_node(&hash_join_node, 0);
     expression_node.subscribe_to_node(&where_node, 0);
     groupby_node.subscribe_to_node(&expression_node, 0);
+    scaler_node.subscribe_to_node(&groupby_node, 0);
 
     // Output reader subscribe to output node.
-    output_reader.subscribe_to_node(&groupby_node, 0);
+    output_reader.subscribe_to_node(&scaler_node, 0);
 
     // Add all the nodes to the service
     let mut service = ExecutionService::<polars::prelude::DataFrame>::create();
+    service.add(scaler_node);
     service.add(groupby_node);
     service.add(expression_node);
     service.add(where_node);

--- a/deepola/wake/examples/tpch_polars/q22.rs
+++ b/deepola/wake/examples/tpch_polars/q22.rs
@@ -7,6 +7,7 @@ use polars::prelude::NamedFrom;
 use polars::series::ChunkCompare;
 use polars::series::Series;
 use wake::graph::*;
+use wake::inference::AggregateScaler;
 use wake::polars_operations::*;
 
 use std::collections::HashMap;
@@ -118,6 +119,11 @@ pub fn query(
     let avg_groupby_node = AccumulatorNode::<DataFrame, AggAccumulator>::new()
         .accumulator(avg_accumulator)
         .build();
+    let avg_scaler_node = AggregateScaler::new_growing()
+        .count_column("c_acctbal_count".into())
+        .scale_sum("c_acctbal_sum".into())
+        .scale_count("c_acctbal_count".into())
+        .into_node();
 
     // Filter by ACCTBAL
     let mut customer_acctbal_merger = MapperDfMerger::new();
@@ -145,6 +151,10 @@ pub fn query(
     let o_custkey_groupby_node = AccumulatorNode::<DataFrame, AggAccumulator>::new()
         .accumulator(o_custkey_accumulator)
         .build();
+    let o_custkey_scaler_node = AggregateScaler::new_growing()
+        .count_column("o_orderkey_count".into())
+        .scale_count("o_orderkey_count".into())
+        .into_node();
 
     // Remove c_custkey from the current order partition.
     let mut orders_customer_merger = MapperDfMerger::new();
@@ -186,10 +196,12 @@ pub fn query(
     customer_where_node.subscribe_to_node(&customer_csvreader_node, 0); // Left Node
     customer_combine_node.subscribe_to_node(&customer_where_node, 0); // Right Node
     avg_groupby_node.subscribe_to_node(&customer_combine_node, 0);
+    avg_scaler_node.subscribe_to_node(&avg_groupby_node, 0);
     customer_acctbal_merger_node.subscribe_to_node(&customer_combine_node, 0);
-    customer_acctbal_merger_node.subscribe_to_node(&avg_groupby_node, 1);
+    customer_acctbal_merger_node.subscribe_to_node(&avg_scaler_node, 1);
     o_custkey_groupby_node.subscribe_to_node(&orders_csvreader_node, 0);
-    orders_customer_merger_node.subscribe_to_node(&o_custkey_groupby_node, 0);
+    o_custkey_scaler_node.subscribe_to_node(&o_custkey_groupby_node, 0);
+    orders_customer_merger_node.subscribe_to_node(&o_custkey_scaler_node, 0);
     orders_customer_merger_node.subscribe_to_node(&customer_acctbal_merger_node, 1);
     select_node.subscribe_to_node(&orders_customer_merger_node, 0);
 
@@ -202,7 +214,9 @@ pub fn query(
     service.add(orders_customer_merger_node);
     service.add(customer_acctbal_merger_node);
     service.add(avg_groupby_node);
+    service.add(avg_scaler_node);
     service.add(o_custkey_groupby_node);
+    service.add(o_custkey_scaler_node);
     service.add(customer_combine_node);
     service.add(customer_where_node);
     service.add(orders_csvreader_node);

--- a/deepola/wake/examples/tpch_polars/q4.rs
+++ b/deepola/wake/examples/tpch_polars/q4.rs
@@ -4,6 +4,7 @@ extern crate wake;
 use polars::prelude::DataFrame;
 use polars::series::ChunkCompare;
 use wake::graph::*;
+use wake::inference::AggregateScaler;
 use wake::polars_operations::*;
 
 use std::collections::HashMap;
@@ -97,10 +98,15 @@ pub fn query(
     let mut agg_accumulator = AggAccumulator::new();
     agg_accumulator
         .set_group_key(vec!["o_orderpriority".into()])
-        .set_aggregates(vec![("l_orderkey_count".into(), vec!["sum".into()])]);
+        .set_aggregates(vec![("l_orderkey_count".into(), vec!["sum".into()])])
+        .set_add_count_column(true);
     let groupby_node = AccumulatorNode::<DataFrame, AggAccumulator>::new()
         .accumulator(agg_accumulator)
         .build();
+    let scaler_node = AggregateScaler::new_growing()
+        .remove_count_column()  // Remove added group count column
+        .scale_sum("l_orderkey_count_sum".into())
+        .into_node();
 
     // SELECT Node
     let select_node = AppenderNode::<DataFrame, MapAppender>::new()
@@ -116,7 +122,8 @@ pub fn query(
     lo_merge_join_node.subscribe_to_node(&orders_where_node, 1); // Right Node
     expression_node.subscribe_to_node(&lo_merge_join_node, 0);
     groupby_node.subscribe_to_node(&expression_node, 0);
-    select_node.subscribe_to_node(&groupby_node, 0);
+    scaler_node.subscribe_to_node(&groupby_node, 0);
+    select_node.subscribe_to_node(&scaler_node, 0);
 
     // Output reader subscribe to output node.
     output_reader.subscribe_to_node(&select_node, 0);
@@ -130,6 +137,7 @@ pub fn query(
     service.add(lo_merge_join_node);
     service.add(expression_node);
     service.add(groupby_node);
+    service.add(scaler_node);
     service.add(select_node);
     service
 }

--- a/deepola/wake/examples/tpch_polars/q5.rs
+++ b/deepola/wake/examples/tpch_polars/q5.rs
@@ -4,6 +4,7 @@ extern crate wake;
 use polars::prelude::{DataFrame, NamedFrom, Series};
 use polars::series::ChunkCompare;
 use wake::graph::*;
+use wake::inference::AggregateScaler;
 use wake::polars_operations::*;
 
 use std::collections::HashMap;
@@ -132,10 +133,15 @@ pub fn query(
     let mut agg_accumulator = AggAccumulator::new();
     agg_accumulator
         .set_group_key(vec!["n_name".into()])
-        .set_aggregates(vec![("disc_price".into(), vec!["sum".into()])]);
+        .set_aggregates(vec![("disc_price".into(), vec!["sum".into()])])
+        .set_add_count_column(true);
     let groupby_node = AccumulatorNode::<DataFrame, AggAccumulator>::new()
         .accumulator(agg_accumulator)
         .build();
+    let scaler_node = AggregateScaler::new_growing()
+        .remove_count_column()  // Remove added group count column
+        .scale_sum("disc_price_sum".into())
+        .into_node();
 
     let select_node = AppenderNode::<DataFrame, MapAppender>::new()
         .appender(MapAppender::new(Box::new(|df: &DataFrame| {
@@ -158,7 +164,8 @@ pub fn query(
     oc_hash_join_node.subscribe_to_node(&customer_csvreader_node, 1);
     expression_node.subscribe_to_node(&oc_hash_join_node, 0);
     groupby_node.subscribe_to_node(&expression_node, 0);
-    select_node.subscribe_to_node(&groupby_node, 0);
+    scaler_node.subscribe_to_node(&groupby_node, 0);
+    select_node.subscribe_to_node(&scaler_node, 0);
 
     // Output reader subscribe to output node.
     output_reader.subscribe_to_node(&select_node, 0);
@@ -180,6 +187,7 @@ pub fn query(
     service.add(lo_merge_join_node);
     service.add(expression_node);
     service.add(groupby_node);
+    service.add(scaler_node);
     service.add(select_node);
     service
 }

--- a/deepola/wake/examples/tpch_polars/q9.rs
+++ b/deepola/wake/examples/tpch_polars/q9.rs
@@ -7,6 +7,7 @@ use polars::prelude::Utf8Methods;
 use polars::series::IntoSeries;
 use polars::series::Series;
 use wake::graph::*;
+use wake::inference::AggregateScaler;
 use wake::polars_operations::*;
 
 use std::collections::HashMap;
@@ -187,10 +188,15 @@ pub fn query(
     let mut agg_accumulator = AggAccumulator::new();
     agg_accumulator
         .set_group_key(vec!["nation".into(), "o_year".into()])
-        .set_aggregates(vec![("profit".into(), vec!["sum".into()])]);
+        .set_aggregates(vec![("profit".into(), vec!["sum".into()])])
+        .set_add_count_column(true);
     let groupby_node = AccumulatorNode::<DataFrame, AggAccumulator>::new()
         .accumulator(agg_accumulator)
         .build();
+    let scaler_node = AggregateScaler::new_growing()
+        .remove_count_column()  // Remove added group count column
+        .scale_sum("profit_sum".into())
+        .into_node();
 
     let select_node = AppenderNode::<DataFrame, MapAppender>::new()
         .appender(MapAppender::new(Box::new(|df: &DataFrame| {
@@ -214,7 +220,8 @@ pub fn query(
     lo_merge_join_node.subscribe_to_node(&orders_csvreader_node, 1);
     expression_node.subscribe_to_node(&lo_merge_join_node, 0);
     groupby_node.subscribe_to_node(&expression_node, 0);
-    select_node.subscribe_to_node(&groupby_node, 0);
+    scaler_node.subscribe_to_node(&groupby_node, 0);
+    select_node.subscribe_to_node(&scaler_node, 0);
 
     // Output reader subscribe to output node.
     output_reader.subscribe_to_node(&select_node, 0);
@@ -235,6 +242,7 @@ pub fn query(
     service.add(lo_merge_join_node);
     service.add(expression_node);
     service.add(groupby_node);
+    service.add(scaler_node);
     service.add(select_node);
     service
 }

--- a/deepola/wake/src/data/meta_type.rs
+++ b/deepola/wake/src/data/meta_type.rs
@@ -10,6 +10,10 @@ pub const DATABLOCK_TOTAL_RECORDS: &str = "reserved.total_blocks";
 pub const DATABLOCK_TYPE_DM: &str = "dm";
 pub const DATABLOCK_TYPE_DA: &str = "da";
 
+pub const DEFAULT_GROUPBY_KEY: &str = "_default_groupby_key";
+pub const DEFAULT_GROUP_COLUMN: &str = "_default_group_column";
+pub const DEFAULT_GROUP_COLUMN_COUNT: &str = "_default_group_column_count";
+
 #[derive(Clone, Debug, PartialEq)]
 pub enum MetaCell {
     Schema(Schema),


### PR DESCRIPTION
Changes:
- Add group count to the preceding aggregate node for estimating group cardinality. 
- Apply to 9 SUM/COUNT queries and 3 AVG queries.

Queries that are improved over no-scale (linear error):
- q1
- q4
- q5
- q6
- q7
- q9
- q12
- q17
- q19

3 Queries that remain the same (converging error):
- q8
- q14
- q22