### PR TITLE
Combine accumulator and scaler to avoid communication across execution nodes

### DIFF
--- a/deepola/wake/examples/tpch_polars/q12.rs
+++ b/deepola/wake/examples/tpch_polars/q12.rs
@@ -111,15 +111,16 @@ pub fn query(
             ("high_line".into(), vec!["sum".into()]),
             ("low_line".into(), vec!["sum".into()]),
         ])
-        .set_add_count_column(true);
+        .set_add_count_column(true)
+        .set_scaler(AggregateScaler::new_growing()
+            .remove_count_column()  // Remove added group count column
+            .scale_sum("high_line_sum".into())
+            .scale_sum("low_line_sum".into())
+            .into_rc()
+        );
     let groupby_node = AccumulatorNode::<DataFrame, AggAccumulator>::new()
         .accumulator(agg_accumulator)
         .build();
-    let scaler_node = AggregateScaler::new_growing()
-        .remove_count_column()  // Remove added group count column
-        .scale_sum("high_line_sum".into())
-        .scale_sum("low_line_sum".into())
-        .into_node();
 
     let select_node = AppenderNode::<DataFrame, MapAppender>::new()
         .appender(MapAppender::new(Box::new(|df: &DataFrame| {
@@ -133,8 +134,7 @@ pub fn query(
     lo_merge_join_node.subscribe_to_node(&orders_csvreader_node, 1);
     expression_node.subscribe_to_node(&lo_merge_join_node, 0);
     groupby_node.subscribe_to_node(&expression_node, 0);
-    scaler_node.subscribe_to_node(&groupby_node, 0);
-    select_node.subscribe_to_node(&scaler_node, 0);
+    select_node.subscribe_to_node(&groupby_node, 0);
 
     // Output reader subscribe to output node.
     output_reader.subscribe_to_node(&select_node, 0);
@@ -147,7 +147,6 @@ pub fn query(
     service.add(lo_merge_join_node);
     service.add(expression_node);
     service.add(groupby_node);
-    service.add(scaler_node);
     service.add(select_node);
     service
 }

--- a/deepola/wake/examples/tpch_polars/q15.rs
+++ b/deepola/wake/examples/tpch_polars/q15.rs
@@ -114,14 +114,15 @@ pub fn query(
             "s_phone".into(),
         ])
         .set_aggregates(vec![("total_revenue".into(), vec!["sum".into()])])
-        .set_add_count_column(true);
+        .set_add_count_column(true)
+        .set_scaler(AggregateScaler::new_growing()
+            .remove_count_column()  // Remove added group count column
+            .scale_sum("total_revenue_sum".into())
+            .into_rc()
+        );
     let groupby_node = AccumulatorNode::<DataFrame, AggAccumulator>::new()
         .accumulator(agg_accumulator)
         .build();
-    let scaler_node = AggregateScaler::new_growing()
-        .remove_count_column()  // Remove added group count column
-        .scale_sum("total_revenue_sum".into())
-        .into_node();
 
     // SELECT Node
     let select_node = AppenderNode::<DataFrame, MapAppender>::new()
@@ -139,8 +140,7 @@ pub fn query(
     ls_hash_join_node.subscribe_to_node(&lineitem_expr_node, 0);
     ls_hash_join_node.subscribe_to_node(&supplier_csvreader_node, 1);
     groupby_node.subscribe_to_node(&ls_hash_join_node, 0);
-    scaler_node.subscribe_to_node(&groupby_node, 0);
-    select_node.subscribe_to_node(&scaler_node, 0);
+    select_node.subscribe_to_node(&groupby_node, 0);
 
     // Output reader subscribe to output node.
     output_reader.subscribe_to_node(&select_node, 0);
@@ -153,7 +153,6 @@ pub fn query(
     service.add(lineitem_expr_node);
     service.add(ls_hash_join_node);
     service.add(groupby_node);
-    service.add(scaler_node);
     service.add(select_node);
     service
 }

--- a/deepola/wake/examples/tpch_polars/q19.rs
+++ b/deepola/wake/examples/tpch_polars/q19.rs
@@ -147,14 +147,15 @@ pub fn query(
     let mut sum_accumulator = AggAccumulator::new();
     sum_accumulator
         .set_aggregates(vec![("disc_price".into(), vec!["sum".into()])])
-        .set_add_count_column(true);
+        .set_add_count_column(true)
+        .set_scaler(AggregateScaler::new_growing()
+            .remove_count_column()  // Remove added group count column
+            .scale_sum("disc_price_sum".into())
+            .into_rc()
+        );
     let groupby_node = AccumulatorNode::<DataFrame, AggAccumulator>::new()
         .accumulator(sum_accumulator)
         .build();
-    let scaler_node = AggregateScaler::new_growing()
-        .remove_count_column()  // Remove added group count column
-        .scale_sum("disc_price_sum".into())
-        .into_node();
 
     // Connect nodes with subscription
     hash_join_node.subscribe_to_node(&lineitem_csvreader_node, 0); // Left Node
@@ -162,14 +163,12 @@ pub fn query(
     where_node.subscribe_to_node(&hash_join_node, 0);
     expression_node.subscribe_to_node(&where_node, 0);
     groupby_node.subscribe_to_node(&expression_node, 0);
-    scaler_node.subscribe_to_node(&groupby_node, 0);
 
     // Output reader subscribe to output node.
-    output_reader.subscribe_to_node(&scaler_node, 0);
+    output_reader.subscribe_to_node(&groupby_node, 0);
 
     // Add all the nodes to the service
     let mut service = ExecutionService::<polars::prelude::DataFrame>::create();
-    service.add(scaler_node);
     service.add(groupby_node);
     service.add(expression_node);
     service.add(where_node);

--- a/deepola/wake/examples/tpch_polars/q4.rs
+++ b/deepola/wake/examples/tpch_polars/q4.rs
@@ -91,14 +91,15 @@ pub fn query(
     agg_accumulator
         .set_group_key(vec!["o_orderpriority".into()])
         .set_aggregates(vec![("l_orderkey_count".into(), vec!["sum".into()])])
-        .set_add_count_column(true);
+        .set_add_count_column(true)
+        .set_scaler(AggregateScaler::new_growing()
+            .remove_count_column()  // Remove added group count column
+            .scale_sum("l_orderkey_count_sum".into())
+            .into_rc()
+        );
     let groupby_node = AccumulatorNode::<DataFrame, AggAccumulator>::new()
         .accumulator(agg_accumulator)
         .build();
-    let scaler_node = AggregateScaler::new_growing()
-        .remove_count_column()  // Remove added group count column
-        .scale_sum("l_orderkey_count_sum".into())
-        .into_node();
 
     // SELECT Node
     let select_node = AppenderNode::<DataFrame, MapAppender>::new()
@@ -114,8 +115,7 @@ pub fn query(
     lo_merge_join_node.subscribe_to_node(&orders_where_node, 1); // Right Node
     expression_node.subscribe_to_node(&lo_merge_join_node, 0);
     groupby_node.subscribe_to_node(&expression_node, 0);
-    scaler_node.subscribe_to_node(&groupby_node, 0);
-    select_node.subscribe_to_node(&scaler_node, 0);
+    select_node.subscribe_to_node(&groupby_node, 0);
 
     // Output reader subscribe to output node.
     output_reader.subscribe_to_node(&select_node, 0);
@@ -129,7 +129,6 @@ pub fn query(
     service.add(lo_merge_join_node);
     service.add(expression_node);
     service.add(groupby_node);
-    service.add(scaler_node);
     service.add(select_node);
     service
 }

--- a/deepola/wake/examples/tpch_polars/q5.rs
+++ b/deepola/wake/examples/tpch_polars/q5.rs
@@ -124,14 +124,15 @@ pub fn query(
     agg_accumulator
         .set_group_key(vec!["n_name".into()])
         .set_aggregates(vec![("disc_price".into(), vec!["sum".into()])])
-        .set_add_count_column(true);
+        .set_add_count_column(true)
+        .set_scaler(AggregateScaler::new_growing()
+            .remove_count_column()  // Remove added group count column
+            .scale_sum("disc_price_sum".into())
+            .into_rc()
+        );
     let groupby_node = AccumulatorNode::<DataFrame, AggAccumulator>::new()
         .accumulator(agg_accumulator)
         .build();
-    let scaler_node = AggregateScaler::new_growing()
-        .remove_count_column()  // Remove added group count column
-        .scale_sum("disc_price_sum".into())
-        .into_node();
 
     let select_node = AppenderNode::<DataFrame, MapAppender>::new()
         .appender(MapAppender::new(Box::new(|df: &DataFrame| {
@@ -154,8 +155,7 @@ pub fn query(
     oc_hash_join_node.subscribe_to_node(&customer_csvreader_node, 1);
     expression_node.subscribe_to_node(&oc_hash_join_node, 0);
     groupby_node.subscribe_to_node(&expression_node, 0);
-    scaler_node.subscribe_to_node(&groupby_node, 0);
-    select_node.subscribe_to_node(&scaler_node, 0);
+    select_node.subscribe_to_node(&groupby_node, 0);
 
     // Output reader subscribe to output node.
     output_reader.subscribe_to_node(&select_node, 0);
@@ -177,7 +177,6 @@ pub fn query(
     service.add(lo_merge_join_node);
     service.add(expression_node);
     service.add(groupby_node);
-    service.add(scaler_node);
     service.add(select_node);
     service
 }

--- a/deepola/wake/examples/tpch_polars/q6.rs
+++ b/deepola/wake/examples/tpch_polars/q6.rs
@@ -55,27 +55,26 @@ pub fn query(
     let mut agg_accumulator = AggAccumulator::new();
     agg_accumulator
         .set_aggregates(vec![("disc_price".into(), vec!["sum".into()])])
-        .set_add_count_column(true);
+        .set_add_count_column(true)
+        .set_scaler(AggregateScaler::new_growing()
+            .remove_count_column()  // Remove added group count column
+            .scale_sum("disc_price_sum".into())
+            .into_rc()
+        );
     let groupby_node = AccumulatorNode::<DataFrame, AggAccumulator>::new()
         .accumulator(agg_accumulator)
         .build();
-    let scaler_node = AggregateScaler::new_growing()
-        .remove_count_column()  // Remove added group count column
-        .scale_sum("disc_price_sum".into())
-        .into_node();
 
     // Connect nodes with subscription
     where_node.subscribe_to_node(&lineitem_csvreader_node, 0);
     expression_node.subscribe_to_node(&where_node, 0);
     groupby_node.subscribe_to_node(&expression_node, 0);
-    scaler_node.subscribe_to_node(&groupby_node, 0);
 
     // Output reader subscribe to output node.
-    output_reader.subscribe_to_node(&scaler_node, 0);
+    output_reader.subscribe_to_node(&groupby_node, 0);
 
     // Add all the nodes to the service
     let mut service = ExecutionService::<polars::prelude::DataFrame>::create();
-    service.add(scaler_node);
     service.add(groupby_node);
     service.add(expression_node);
     service.add(where_node);

--- a/deepola/wake/examples/tpch_polars/q8.rs
+++ b/deepola/wake/examples/tpch_polars/q8.rs
@@ -186,15 +186,16 @@ pub fn query(
             ("volume".into(), vec!["sum".into()]),
             ("masked_volume".into(), vec!["sum".into()]),
         ])
-        .set_add_count_column(true);
+        .set_add_count_column(true)
+        .set_scaler(AggregateScaler::new_growing()
+            .remove_count_column()  // Remove added group count column
+            .scale_sum("volume_sum".into())
+            .scale_sum("masked_volume_sum".into())
+            .into_rc()
+        );
     let groupby_node = AccumulatorNode::<DataFrame, AggAccumulator>::new()
         .accumulator(agg_accumulator)
         .build();
-    let scaler_node = AggregateScaler::new_growing()
-        .remove_count_column()  // Remove added group count column
-        .scale_sum("volume_sum".into())
-        .scale_sum("masked_volume_sum".into())
-        .into_node();
 
     let select_node = AppenderNode::<DataFrame, MapAppender>::new()
         .appender(MapAppender::new(Box::new(|df: &DataFrame| {
@@ -242,9 +243,8 @@ pub fn query(
     expression_node.subscribe_to_node(&lo_merge_join_node, 0);
 
     groupby_node.subscribe_to_node(&expression_node, 0);
-    scaler_node.subscribe_to_node(&groupby_node, 0);
 
-    select_node.subscribe_to_node(&scaler_node, 0);
+    select_node.subscribe_to_node(&groupby_node, 0);
 
     // Output reader subscribe to output node.
     output_reader.subscribe_to_node(&select_node, 0);
@@ -271,7 +271,6 @@ pub fn query(
     service.add(lo_merge_join_node);
     service.add(expression_node);
     service.add(groupby_node);
-    service.add(scaler_node);
     service.add(select_node);
     service
 }

--- a/deepola/wake/examples/tpch_polars/q9.rs
+++ b/deepola/wake/examples/tpch_polars/q9.rs
@@ -163,14 +163,15 @@ pub fn query(
     agg_accumulator
         .set_group_key(vec!["nation".into(), "o_year".into()])
         .set_aggregates(vec![("profit".into(), vec!["sum".into()])])
-        .set_add_count_column(true);
+        .set_add_count_column(true)
+        .set_scaler(AggregateScaler::new_growing()
+            .remove_count_column()  // Remove added group count column
+            .scale_sum("profit_sum".into())
+            .into_rc()
+        );
     let groupby_node = AccumulatorNode::<DataFrame, AggAccumulator>::new()
         .accumulator(agg_accumulator)
         .build();
-    let scaler_node = AggregateScaler::new_growing()
-        .remove_count_column()  // Remove added group count column
-        .scale_sum("profit_sum".into())
-        .into_node();
 
     let select_node = AppenderNode::<DataFrame, MapAppender>::new()
         .appender(MapAppender::new(Box::new(|df: &DataFrame| {
@@ -194,8 +195,7 @@ pub fn query(
     lo_merge_join_node.subscribe_to_node(&orders_csvreader_node, 1);
     expression_node.subscribe_to_node(&lo_merge_join_node, 0);
     groupby_node.subscribe_to_node(&expression_node, 0);
-    scaler_node.subscribe_to_node(&groupby_node, 0);
-    select_node.subscribe_to_node(&scaler_node, 0);
+    select_node.subscribe_to_node(&groupby_node, 0);
 
     // Output reader subscribe to output node.
     output_reader.subscribe_to_node(&select_node, 0);
@@ -216,7 +216,6 @@ pub fn query(
     service.add(lo_merge_join_node);
     service.add(expression_node);
     service.add(groupby_node);
-    service.add(scaler_node);
     service.add(select_node);
     service
 }

--- a/deepola/wake/src/polars_operations/accumulator/base.rs
+++ b/deepola/wake/src/polars_operations/accumulator/base.rs
@@ -2,7 +2,8 @@ use std::marker::PhantomData;
 
 use getset::{Getters, Setters};
 
-use crate::{graph::ExecutionNode, processor::MessageProcessor};
+use crate::graph::ExecutionNode;
+use crate::processor::StreamProcessor;
 
 /// Factory class for creating an ExecutionNode that can perform AccumulatorOp.
 #[derive(Getters, Setters)]
@@ -26,7 +27,7 @@ impl<T, P: AccumulatorOp<T> + Clone> Default for AccumulatorNode<T, P> {
 
 impl<T: 'static + Send, P> AccumulatorNode<T, P>
 where
-    P: 'static + AccumulatorOp<T> + MessageProcessor<T> + Clone,
+    P: 'static + AccumulatorOp<T> + StreamProcessor<T> + Clone,
 {
     pub fn new() -> Self {
         AccumulatorNode::default()


### PR DESCRIPTION
Previously, each scaler is a separate execution node subscribing to the previous aggregation accumulator and subscribed by the next node. This could lead to unnecessary cloning and communication across nodes, as well as overly complicated query implementations.
- Pull out the common trait on common scalers and count distinct scaler
- Add a scaler as an attachment to the accumulator