### PR TITLE
Extend query Q24 as Wander Join's modified Q10

### DIFF
--- a/deepola/wake/examples/tpch_polars/main.rs
+++ b/deepola/wake/examples/tpch_polars/main.rs
@@ -23,6 +23,7 @@ mod q20;
 mod q21;
 mod q22;
 mod q23;
+mod q24;
 mod q3;
 mod q4;
 mod q5;
@@ -111,6 +112,7 @@ pub fn get_query_service(
         "q21" => q21::query(table_input, output_reader),
         "q22" => q22::query(table_input, output_reader),
         "q23" => q23::query(table_input, output_reader),
+        "q24" => q24::query(table_input, output_reader),
         "q3" => q3::query(table_input, output_reader),
         "q4" => q4::query(table_input, output_reader),
         "q5" => q5::query(table_input, output_reader),

--- a/deepola/wake/examples/tpch_polars/main.rs
+++ b/deepola/wake/examples/tpch_polars/main.rs
@@ -24,6 +24,7 @@ mod q21;
 mod q22;
 mod q23;
 mod q24;
+mod q25;
 mod q3;
 mod q4;
 mod q5;
@@ -113,6 +114,7 @@ pub fn get_query_service(
         "q22" => q22::query(table_input, output_reader),
         "q23" => q23::query(table_input, output_reader),
         "q24" => q24::query(table_input, output_reader),
+        "q25" => q25::query(table_input, output_reader),
         "q3" => q3::query(table_input, output_reader),
         "q4" => q4::query(table_input, output_reader),
         "q5" => q5::query(table_input, output_reader),

--- a/deepola/wake/examples/tpch_polars/q24.rs
+++ b/deepola/wake/examples/tpch_polars/q24.rs
@@ -1,0 +1,157 @@
+use crate::prelude::*;
+
+/// WanderJoin's modified Q3 by dropping select and groupby.
+// TODO: Do we drop date comparison as well?
+/// This node implements the following SQL query
+// select
+//  sum(l_extendedprice * (1 - l_discount)) as revenue,
+// from
+//  customer,
+//  orders,
+//  lineitem,
+//  nation
+// where
+//  c_custkey = o_custkey
+//  and l_orderkey = o_orderkey
+//  and o_orderdate >= date '1993-10-01'
+//  and o_orderdate < date '1993-10-01' + interval '3' month
+//  and l_returnflag = 'R'
+//  and c_nationkey = n_nationkey
+
+pub fn query(
+    tableinput: HashMap<String, TableInput>,
+    output_reader: &mut NodeReader<polars::prelude::DataFrame>,
+) -> ExecutionService<polars::prelude::DataFrame> {
+    // Create a HashMap that stores table name and the columns in that query.
+    let table_columns = HashMap::from([
+        (
+            "lineitem".into(),
+            vec![
+                "l_orderkey",
+                "l_extendedprice",
+                "l_discount",
+                "l_returnflag",
+            ],
+        ),
+        (
+            "orders".into(),
+            vec!["o_orderkey", "o_custkey", "o_orderdate"],
+        ),
+        (
+            "customer".into(),
+            vec![
+                "c_custkey",
+                "c_nationkey",
+                "c_name",
+                "c_acctbal",
+                "c_phone",
+                "c_address",
+                "c_comment",
+            ],
+        ),
+        ("nation".into(), vec!["n_nationkey", "n_name"]),
+    ]);
+
+    // CSVReaderNode would be created for this table.
+    let lineitem_csvreader_node = build_reader_node("lineitem".into(), &tableinput, &table_columns);
+    let orders_csvreader_node = build_reader_node("orders".into(), &tableinput, &table_columns);
+    let customer_csvreader_node = build_reader_node("customer".into(), &tableinput, &table_columns);
+    let nation_csvreader_node = build_reader_node("nation".into(), &tableinput, &table_columns);
+
+    // WHERE Node
+    let lineitem_where_node = AppenderNode::<DataFrame, MapAppender>::new()
+        .appender(MapAppender::new(Box::new(|df: &DataFrame| {
+            let a = df.column("l_returnflag").unwrap();
+            let mask = a.equal("R").unwrap();
+            df.filter(&mask).unwrap()
+        })))
+        .build();
+    let orders_where_node = AppenderNode::<DataFrame, MapAppender>::new()
+        .appender(MapAppender::new(Box::new(|df: &DataFrame| {
+            let var_date_1 = days_since_epoch(1993,10,1);
+            let var_date_2 = days_since_epoch(1994,1,1);
+            let a = df.column("o_orderdate").unwrap();
+            let mask = a.gt_eq(var_date_1).unwrap() & a.lt(var_date_2).unwrap();
+            df.filter(&mask).unwrap()
+        })))
+        .build();
+
+    // HASH JOIN Node
+    let cn_hash_join_node = HashJoinBuilder::new()
+        .left_on(vec!["c_nationkey".into()])
+        .right_on(vec!["n_nationkey".into()])
+        .build();
+
+    let oc_hash_join_node = HashJoinBuilder::new()
+        .left_on(vec!["o_custkey".into()])
+        .right_on(vec!["c_custkey".into()])
+        .build();
+
+    // Merge JOIN Node
+    let mut merger = SortedDfMerger::new();
+    merger.set_left_on(vec!["l_orderkey".into()]);
+    merger.set_right_on(vec!["o_orderkey".into()]);
+    let lo_merge_join_node = MergerNode::<DataFrame, SortedDfMerger>::new()
+        .merger(merger)
+        .build();
+
+    let expression_node = AppenderNode::<DataFrame, MapAppender>::new()
+        .appender(MapAppender::new(Box::new(|df: &DataFrame| {
+            let extended_price = df.column("l_extendedprice").unwrap();
+            let discount = df.column("l_discount").unwrap();
+            let disc_price = Series::new(
+                "disc_price",
+                extended_price
+                    .cast(&polars::datatypes::DataType::Float64)
+                    .unwrap()
+                    * (discount * -1f64 + 1f64),
+            );
+            df.hstack(&[disc_price]).unwrap()
+        })))
+        .build();
+
+    // GROUP BY AGGREGATE Node
+    let mut sum_accumulator = AggAccumulator::new();
+    sum_accumulator
+        .set_aggregates(vec![("disc_price".into(), vec!["sum".into()])])
+        .set_add_count_column(true)
+        .set_scaler(AggregateScaler::new_growing()
+            .remove_count_column()  // Remove added group count column
+            .scale_sum("disc_price_sum".into())
+            .into_rc()
+        );
+
+    let groupby_node = AccumulatorNode::<DataFrame, AggAccumulator>::new()
+        .accumulator(sum_accumulator)
+        .build();
+
+    // Connect nodes with subscription
+    lineitem_where_node.subscribe_to_node(&lineitem_csvreader_node, 0);
+    orders_where_node.subscribe_to_node(&orders_csvreader_node, 0);
+    cn_hash_join_node.subscribe_to_node(&customer_csvreader_node, 0);
+    cn_hash_join_node.subscribe_to_node(&nation_csvreader_node, 1);
+    oc_hash_join_node.subscribe_to_node(&orders_where_node, 0);
+    oc_hash_join_node.subscribe_to_node(&cn_hash_join_node, 1);
+    lo_merge_join_node.subscribe_to_node(&lineitem_where_node, 0); // Left Node
+    lo_merge_join_node.subscribe_to_node(&oc_hash_join_node, 1); // Right Node
+    expression_node.subscribe_to_node(&lo_merge_join_node, 0);
+    groupby_node.subscribe_to_node(&expression_node, 0);
+
+    // Output reader subscribe to output node.
+    output_reader.subscribe_to_node(&groupby_node, 0);
+
+    // Add all the nodes to the service
+    let mut service = ExecutionService::<polars::prelude::DataFrame>::create();
+    service.add(lineitem_csvreader_node);
+    service.add(customer_csvreader_node);
+    service.add(orders_csvreader_node);
+    service.add(nation_csvreader_node);
+    service.add(lineitem_where_node);
+    service.add(orders_where_node);
+    service.add(cn_hash_join_node);
+    service.add(oc_hash_join_node);
+    service.add(lo_merge_join_node);
+    service.add(expression_node);
+    service.add(groupby_node);
+    service
+}

--- a/deepola/wake/examples/tpch_polars/q25.rs
+++ b/deepola/wake/examples/tpch_polars/q25.rs
@@ -1,0 +1,159 @@
+use crate::prelude::*;
+
+/// WanderJoin's modified Q7.
+/// Refer: https://github.com/InitialDLab/XDB/blob/master/queries/query7_selection.sql
+/// This node implements the following SQL query
+// SELECT SUM(l_extendedprice * (1 - l_discount))
+// FROM nation n1, supplier, lineitem, orders, customer, nation n2
+// WHERE   s_suppkey = l_suppkey
+//     AND o_orderkey = l_orderkey
+//     AND c_custkey = o_custkey
+//     AND s_nationkey = n1.n_nationkey
+//     AND c_nationkey = n2.n_nationkey
+// 	   AND n1.n_name = 'CHINA'
+//     AND l_shipdate > date '1994-05-01';
+
+pub fn query(
+    tableinput: HashMap<String, TableInput>,
+    output_reader: &mut NodeReader<polars::prelude::DataFrame>,
+) -> ExecutionService<polars::prelude::DataFrame> {
+    // Create a HashMap that stores table name and the columns in that query.
+    let table_columns = HashMap::from([
+        ("nation".into(), vec!["n_nationkey", "n_name"]),
+        ("customer".into(), vec!["c_custkey", "c_nationkey"]),
+        ("supplier".into(), vec!["s_suppkey", "s_nationkey"]),
+        ("orders".into(), vec!["o_orderkey", "o_custkey"]),
+        (
+            "lineitem".into(),
+            vec![
+                "l_orderkey",
+                "l_suppkey",
+                "l_shipdate",
+                "l_extendedprice",
+                "l_discount",
+            ],
+        ),
+    ]);
+
+    // CSV Reader Nodes.
+    let nation_csvreader_node = build_reader_node("nation".into(), &tableinput, &table_columns);
+    let lineitem_csvreader_node = build_reader_node("lineitem".into(), &tableinput, &table_columns);
+    let orders_csvreader_node = build_reader_node("orders".into(), &tableinput, &table_columns);
+    let supplier_csvreader_node = build_reader_node("supplier".into(), &tableinput, &table_columns);
+    let customer_csvreader_node = build_reader_node("customer".into(), &tableinput, &table_columns);
+
+    // WHERE Nodes
+    let nation_where_node = AppenderNode::<DataFrame, MapAppender>::new()
+        .appender(MapAppender::new(Box::new(|df: &DataFrame| {
+            let n_name = df.column("n_name").unwrap();
+            let mask = n_name.equal("CHINA").unwrap();
+            df.filter(&mask).unwrap()
+        })))
+        .build();
+
+    // WHERE Node
+    let lineitem_where_node = AppenderNode::<DataFrame, MapAppender>::new()
+        .appender(MapAppender::new(Box::new(|df: &DataFrame| {
+            let var_date_1 = days_since_epoch(1994,5,1);
+            let l_shipdate = df.column("l_shipdate").unwrap();
+            let mask = l_shipdate.gt(var_date_1).unwrap();
+            df.filter(&mask).unwrap()
+        })))
+        .build();
+
+    // HASH JOIN Node
+    let cn_hash_join_node = HashJoinBuilder::new()
+        .left_on(vec!["c_nationkey".into()])
+        .right_on(vec!["n_nationkey".into()])
+        .build();
+
+    let sn_hash_join_node = HashJoinBuilder::new()
+        .left_on(vec!["s_nationkey".into()])
+        .right_on(vec!["n_nationkey".into()])
+        .build();
+
+    let oc_hash_join_node = HashJoinBuilder::new()
+        .left_on(vec!["o_custkey".into()])
+        .right_on(vec!["c_custkey".into()])
+        .build();
+
+    let ls_hash_join_node = HashJoinBuilder::new()
+        .left_on(vec!["l_suppkey".into()])
+        .right_on(vec!["s_suppkey".into()])
+        .build();
+
+    // Merge JOIN Node
+    let mut merger = SortedDfMerger::new();
+    merger.set_left_on(vec!["l_orderkey".into()]);
+    merger.set_right_on(vec!["o_orderkey".into()]);
+    let lo_merge_join_node = MergerNode::<DataFrame, SortedDfMerger>::new()
+        .merger(merger)
+        .build();
+
+    let expression_node = AppenderNode::<DataFrame, MapAppender>::new()
+        .appender(MapAppender::new(Box::new(|df: &DataFrame| {
+            let extended_price = df.column("l_extendedprice").unwrap();
+            let discount = df.column("l_discount").unwrap();
+            let disc_price = Series::new(
+                "disc_price",
+                extended_price
+                    .cast(&polars::datatypes::DataType::Float64)
+                    .unwrap()
+                    * (discount * -1f64 + 1f64),
+            );
+            df.hstack(&[disc_price]).unwrap()
+        })))
+        .build();
+
+    // GROUP BY AGGREGATE Node
+    let mut sum_accumulator = AggAccumulator::new();
+    sum_accumulator
+        .set_aggregates(vec![("disc_price".into(), vec!["sum".into()])])
+        .set_add_count_column(true)
+        .set_scaler(AggregateScaler::new_growing()
+            .remove_count_column()  // Remove added group count column
+            .scale_sum("disc_price_sum".into())
+            .into_rc()
+        );
+
+    let groupby_node = AccumulatorNode::<DataFrame, AggAccumulator>::new()
+        .accumulator(sum_accumulator)
+        .build();
+
+    // Connect nodes with subscription
+    lineitem_where_node.subscribe_to_node(&lineitem_csvreader_node, 0);
+    cn_hash_join_node.subscribe_to_node(&customer_csvreader_node, 0);
+    cn_hash_join_node.subscribe_to_node(&nation_csvreader_node, 1);
+    nation_where_node.subscribe_to_node(&nation_csvreader_node, 0);
+    sn_hash_join_node.subscribe_to_node(&supplier_csvreader_node, 0);
+    sn_hash_join_node.subscribe_to_node(&nation_where_node, 1);
+    ls_hash_join_node.subscribe_to_node(&lineitem_where_node, 0);
+    ls_hash_join_node.subscribe_to_node(&sn_hash_join_node, 1);
+    oc_hash_join_node.subscribe_to_node(&orders_csvreader_node, 0);
+    oc_hash_join_node.subscribe_to_node(&cn_hash_join_node, 1);
+    lo_merge_join_node.subscribe_to_node(&ls_hash_join_node, 0); // Left Node
+    lo_merge_join_node.subscribe_to_node(&oc_hash_join_node, 1); // Right Node
+    expression_node.subscribe_to_node(&lo_merge_join_node, 0);
+    groupby_node.subscribe_to_node(&expression_node, 0);
+
+    // Output reader subscribe to output node.
+    output_reader.subscribe_to_node(&groupby_node, 0);
+
+    // Add all the nodes to the service
+    let mut service = ExecutionService::<polars::prelude::DataFrame>::create();
+    service.add(lineitem_csvreader_node);
+    service.add(customer_csvreader_node);
+    service.add(orders_csvreader_node);
+    service.add(nation_csvreader_node);
+    service.add(supplier_csvreader_node);
+    service.add(nation_where_node);
+    service.add(lineitem_where_node);
+    service.add(cn_hash_join_node);
+    service.add(sn_hash_join_node);
+    service.add(oc_hash_join_node);
+    service.add(ls_hash_join_node);
+    service.add(lo_merge_join_node);
+    service.add(expression_node);
+    service.add(groupby_node);
+    service
+}

--- a/deepola/wake/src/polars_operations/reader/csvreader.rs
+++ b/deepola/wake/src/polars_operations/reader/csvreader.rs
@@ -137,7 +137,7 @@ impl StreamProcessor<DataFrame> for CSVReader {
                 Payload::Signal(_) => break,
                 Payload::Some(dblock) => {
                     let mut metadata = dblock.metadata().clone();
-                    let expected_total_records =
+                    let mut expected_total_records =
                         if let Some(count) = metadata.get(DATABLOCK_TOTAL_RECORDS) {
                             f64::from(count)
                         } else {
@@ -160,7 +160,7 @@ impl StreamProcessor<DataFrame> for CSVReader {
                             if index == num_files - 1 {
                                 // lineitem's cardinality estimate of 6_000_000 * SF is approximate.
                                 // For some scales, this value is smaller than 6_000_000 * SF.
-                                currect_total_records = expected_total_records;
+                                expected_total_records = currect_total_records;
                             }
                             if let Some(cardinality) = metadata.get_mut(DATABLOCK_CARDINALITY) {
                                 *cardinality = MetaCell::from(f64::min(1.0,

--- a/deepola/wake/src/polars_operations/reader/parquetreader.rs
+++ b/deepola/wake/src/polars_operations/reader/parquetreader.rs
@@ -91,7 +91,7 @@ impl StreamProcessor<DataFrame> for ParquetReader {
                 Payload::Signal(_) => break,
                 Payload::Some(dblock) => {
                     let mut metadata = dblock.metadata().clone();
-                    let expected_total_records =
+                    let mut expected_total_records =
                         if let Some(count) = metadata.get(DATABLOCK_TOTAL_RECORDS) {
                             f64::from(count)
                         } else {
@@ -114,7 +114,7 @@ impl StreamProcessor<DataFrame> for ParquetReader {
                             if index == num_files - 1 {
                                 // lineitem's cardinality estimate of 6_000_000 * SF is approximate.
                                 // For some scales, this value is smaller than 6_000_000 * SF.
-                                currect_total_records = expected_total_records;
+                                expected_total_records = currect_total_records;
                             }
                             if let Some(cardinality) = metadata.get_mut(DATABLOCK_CARDINALITY) {
                                 *cardinality = MetaCell::from(f64::min(1.0,

--- a/deepola/wake/src/polars_operations/reader/parquetreader.rs
+++ b/deepola/wake/src/polars_operations/reader/parquetreader.rs
@@ -103,13 +103,19 @@ impl StreamProcessor<DataFrame> for ParquetReader {
                         // This must be a length-one Polars series containing
                         // file names in its rows
                         let rows = series.utf8().unwrap();
+                        let num_files = rows.len();
 
                         // each file name produces multiple Series (each is a column)
-                        for filename in rows {
+                        for (index,filename) in rows.into_iter().enumerate() {
                             let output_df = self.dataframe_from_filename(filename.unwrap());
 
                             // Update record count
                             currect_total_records += output_df.height() as f64;
+                            if index == num_files - 1 {
+                                // lineitem's cardinality estimate of 6_000_000 * SF is approximate.
+                                // For some scales, this value is smaller than 6_000_000 * SF.
+                                currect_total_records = expected_total_records;
+                            }
                             if let Some(cardinality) = metadata.get_mut(DATABLOCK_CARDINALITY) {
                                 *cardinality = MetaCell::from(f64::min(1.0,
                                     currect_total_records / expected_total_records));


### PR DESCRIPTION
Open Question: Should we drop date filters too? The paper (https://www.cse.ust.hk/~yike/sigmod16.pdf) is unclear. https://github.com/InitialDLab/wj-inmem/tree/master/src has many Q10 implementations; I'm not sure which one is the published one.

Drop groupby operation and according select columns. 