### PR TITLE
Fix correctness errors in Wake queries

### DIFF
--- a/baselines/polars/tpch/polars_queries/q20.py
+++ b/baselines/polars/tpch/polars_queries/q20.py
@@ -36,7 +36,7 @@ def q():
         part_supp_ds
         .join(part_subquery, left_on="ps_partkey", right_on="p_partkey")
         .join(lineitem_group_ds, left_on=["ps_partkey","ps_suppkey"], right_on=["l_partkey","l_suppkey"])
-        .filter(pl.col("ps_availqty") > pl.col("l_quantity_sum"))
+        .filter(pl.col("ps_availqty") > pl.col("l_quantity_sum").floor())
         .select("ps_suppkey")
     ).collect()
 

--- a/deepola/wake/Cargo.toml
+++ b/deepola/wake/Cargo.toml
@@ -24,7 +24,7 @@ simple-error = "0.2.3"
 structopt = "0.3.26"
 uuid = { version = "0.8", features = ["v4"] }
 jemallocator = "0.3.2"
-polars = { version = "0.23.2", features = ["parquet", "dtype-date"] }
+polars = { version = "0.23.2", features = ["parquet", "dtype-date", "round_series"] }
 glob = "0.3.0"
 alphanumeric-sort = "1.4.4"
 serde = { version = "1.0", features = ["derive"] }

--- a/deepola/wake/examples/tpch_polars/q10.rs
+++ b/deepola/wake/examples/tpch_polars/q10.rs
@@ -132,9 +132,9 @@ pub fn query(
             "o_custkey".into(),
             "c_name".into(),
             "c_acctbal".into(),
-            "c_phone".into(),
             "n_name".into(),
             "c_address".into(),
+            "c_phone".into(),
             "c_comment".into(),
         ])
         .set_aggregates(vec![("disc_price".into(), vec!["sum".into()])]);
@@ -150,9 +150,9 @@ pub fn query(
                 "c_name",
                 "disc_price_sum",
                 "c_acctbal",
-                "c_phone",
                 "n_name",
                 "c_address",
+                "c_phone",
                 "c_comment",
             ];
             df.select(cols)

--- a/deepola/wake/examples/tpch_polars/q13.rs
+++ b/deepola/wake/examples/tpch_polars/q13.rs
@@ -92,7 +92,7 @@ pub fn query(
         .appender(MapAppender::new(Box::new(|df| {
             let mut df = df.clone();
             df.apply("o_orderkey_unit_sum", |column| {
-                column.cast(&polars::datatypes::DataType::UInt32).unwrap()
+                column.round(0).unwrap().cast(&polars::datatypes::DataType::UInt32).unwrap()
             }).expect("Failed to cast to integer");
             df.groupby(vec!["o_orderkey_unit_sum"])
                 .unwrap()

--- a/deepola/wake/examples/tpch_polars/q19.rs
+++ b/deepola/wake/examples/tpch_polars/q19.rs
@@ -64,6 +64,23 @@ pub fn query(
     let lineitem_csvreader_node = build_reader_node("lineitem".into(), &tableinput, &table_columns);
     let part_csvreader_node = build_reader_node("part".into(), &tableinput, &table_columns);
 
+    // Predicate Pushdown
+    let lineitem_where_node = AppenderNode::<DataFrame, MapAppender>::new()
+        .appender(MapAppender::new(Box::new(|df: &DataFrame| {
+            let l_shipmode = df.column("l_shipmode").unwrap();
+            let l_shipinstruct = df.column("l_shipinstruct").unwrap();
+            const L_SHIPMODE_LIST: [&'static str; 2] = ["AIR", "AIR REG"];
+            let mask = l_shipinstruct.equal("DELIVER IN PERSON").unwrap()
+                & l_shipmode
+                    .utf8()
+                    .unwrap()
+                    .into_no_null_iter()
+                    .map(|v| L_SHIPMODE_LIST.contains(&v) as bool)
+                    .collect();
+            df.filter(&mask).unwrap()
+        })))
+        .build();
+
     // HASH JOIN Node
     let hash_join_node = HashJoinBuilder::new()
         .left_on(vec!["l_partkey".into()])
@@ -73,23 +90,16 @@ pub fn query(
     // WHERE Node
     let where_node = AppenderNode::<DataFrame, MapAppender>::new()
         .appender(MapAppender::new(Box::new(|df: &DataFrame| {
+            let p_size = df.column("p_size").unwrap();
             let p_brand = df.column("p_brand").unwrap();
             let p_container = df.column("p_container").unwrap();
-            let p_size = df.column("p_size").unwrap();
             let l_quantity = df.column("l_quantity").unwrap();
-            let l_shipmode = df.column("l_shipmode").unwrap();
-            let l_shipinstruct = df.column("l_shipinstruct").unwrap();
-
-            let common_mask = p_size.gt_eq(1i32).unwrap()
-                & l_shipinstruct.equal("DELIVER IN PERSON").unwrap()
-                & l_shipmode
-                    .utf8()
-                    .unwrap()
-                    .into_no_null_iter()
-                    .map(|v| vec!["AIR", "AIR REG"].contains(&v) as bool)
-                    .collect();
+            const P_CONTAINER_LIST_1: [&'static str; 4] = ["SM CASE", "SM BOX", "SM PACK", "SM PKG"];
+            const P_CONTAINER_LIST_2: [&'static str; 4] = ["MED BAG", "MED BOX", "MED PKG", "MED PACK"];
+            const P_CONTAINER_LIST_3: [&'static str; 4] = ["LG CASE", "LG BOX", "LG PACK", "LG PKG"];
 
             let mask1 = p_brand.equal("Brand#12").unwrap()
+                & p_size.gt_eq(1i32).unwrap()
                 & p_size.lt_eq(5i32).unwrap()
                 & l_quantity.gt_eq(1i32).unwrap()
                 & l_quantity.lt_eq(11i32).unwrap()
@@ -97,10 +107,11 @@ pub fn query(
                     .utf8()
                     .unwrap()
                     .into_no_null_iter()
-                    .map(|v| vec!["SM CASE", "SM BOX", "SM PACK", "SM PKG"].contains(&v) as bool)
+                    .map(|v| P_CONTAINER_LIST_1.contains(&v) as bool)
                     .collect();
 
             let mask2 = p_brand.equal("Brand#23").unwrap()
+                & p_size.gt_eq(1i32).unwrap()
                 & p_size.lt_eq(10i32).unwrap()
                 & l_quantity.gt_eq(10i32).unwrap()
                 & l_quantity.lt_eq(20i32).unwrap()
@@ -108,10 +119,11 @@ pub fn query(
                     .utf8()
                     .unwrap()
                     .into_no_null_iter()
-                    .map(|v| vec!["MED BAG", "MED BOX", "MED PKG", "MED PACK"].contains(&v) as bool)
+                    .map(|v| P_CONTAINER_LIST_2.contains(&v) as bool)
                     .collect();
 
             let mask3 = p_brand.equal("Brand#34").unwrap()
+                & p_size.gt_eq(1i32).unwrap()
                 & p_size.lt_eq(15i32).unwrap()
                 & l_quantity.gt_eq(20i32).unwrap()
                 & l_quantity.lt_eq(30i32).unwrap()
@@ -119,10 +131,10 @@ pub fn query(
                     .utf8()
                     .unwrap()
                     .into_no_null_iter()
-                    .map(|v| vec!["LG CASE", "LG BOX", "LG PACK", "LG PKG"].contains(&v) as bool)
+                    .map(|v| P_CONTAINER_LIST_3.contains(&v) as bool)
                     .collect();
 
-            let mask = common_mask & (mask1 | mask2 | mask3);
+            let mask = mask1 | mask2 | mask3;
             df.filter(&mask).unwrap()
         })))
         .build();
@@ -158,7 +170,8 @@ pub fn query(
         .build();
 
     // Connect nodes with subscription
-    hash_join_node.subscribe_to_node(&lineitem_csvreader_node, 0); // Left Node
+    lineitem_where_node.subscribe_to_node(&lineitem_csvreader_node, 0);
+    hash_join_node.subscribe_to_node(&lineitem_where_node, 0); // Left Node
     hash_join_node.subscribe_to_node(&part_csvreader_node, 1); // Right Node
     where_node.subscribe_to_node(&hash_join_node, 0);
     expression_node.subscribe_to_node(&where_node, 0);
@@ -173,6 +186,7 @@ pub fn query(
     service.add(expression_node);
     service.add(where_node);
     service.add(hash_join_node);
+    service.add(lineitem_where_node);
     service.add(part_csvreader_node);
     service.add(lineitem_csvreader_node);
     service

--- a/deepola/wake/examples/tpch_polars/q20.rs
+++ b/deepola/wake/examples/tpch_polars/q20.rs
@@ -139,6 +139,7 @@ pub fn query(
         .accumulator(ps_accumulator)
         .build();
 
+    // The result is obtained when right goes EOF. Not when left does.
     let mut ps_availqty_merger = MapperDfMerger::new();
     ps_availqty_merger.set_mapper(Box::new(|left_df: &DataFrame, right_df: &DataFrame| {
         let joined_df = left_df
@@ -163,6 +164,7 @@ pub fn query(
             .count()
             .unwrap()
     }));
+    ps_availqty_merger.set_eof_behavior(MapperDfEOFBehavior::RightEOF);
     let ps_availqty_merger_node = MergerNode::<DataFrame, MapperDfMerger>::new()
         .merger(ps_availqty_merger)
         .build();

--- a/deepola/wake/examples/tpch_polars/q20.rs
+++ b/deepola/wake/examples/tpch_polars/q20.rs
@@ -151,8 +151,8 @@ pub fn query(
                 None,
             )
             .unwrap();
-        let ps_availqty = joined_df.column("ps_availqty").unwrap();
-        let ps_availqty_avg = joined_df.column("l_quantity_sum").unwrap() * 0.5f64;
+        let ps_availqty = joined_df.column("ps_availqty").unwrap(); // Integer
+        let ps_availqty_avg = (joined_df.column("l_quantity_sum").unwrap().cast(&polars::datatypes::DataType::Float64).unwrap() * 0.5f64).floor().unwrap();
         let mask = ps_availqty.gt(&ps_availqty_avg).unwrap();
         joined_df
             .filter(&mask)

--- a/deepola/wake/examples/tpch_polars/q21.rs
+++ b/deepola/wake/examples/tpch_polars/q21.rs
@@ -197,12 +197,13 @@ pub fn query(
     let mut accumulator1 = AggAccumulator::new();
     accumulator1
         .set_group_key(vec!["s_name".into()])
-        .set_aggregates(vec![("l_suppkey_count".into(), vec!["sum".into()])]);
-        // .set_scaler(AggregateScaler::new_growing()
-        //     .count_column("l_orderkey_count".into())
-        //     .scale_count("l_orderkey_count".into())
-        //     .into_rc()
-        // );
+        .set_aggregates(vec![("l_suppkey_count".into(), vec!["sum".into()])])
+        .set_add_count_column(true)
+        .set_scaler(AggregateScaler::new_growing()
+            .remove_count_column()  // Remove added group count column
+            .scale_sum("l_suppkey_count_sum".into())
+            .into_rc()
+        );
     let groupby_node = AccumulatorNode::<DataFrame, AggAccumulator>::new()
         .accumulator(accumulator1)
         .build();


### PR DESCRIPTION
- Q2, Q17: Add block on sub-aggregate.
- Q10: Re-order output columns.
- Q20: Add an option to configure EOF in MapperDfMerge.
- Q19: Improve performance by moving predicate closer to read.
- Q13: Floating point error
- Q20: Floating point error
- Q21: Instead of counting orders, had to count items.