### PR TITLE
Set cardinality fraction to 1.0 on last input file

### DIFF
--- a/deepola/wake/src/polars_operations/reader/csvreader.rs
+++ b/deepola/wake/src/polars_operations/reader/csvreader.rs
@@ -137,7 +137,7 @@ impl StreamProcessor<DataFrame> for CSVReader {
                 Payload::Signal(_) => break,
                 Payload::Some(dblock) => {
                     let mut metadata = dblock.metadata().clone();
-                    let expected_total_records =
+                    let mut expected_total_records =
                         if let Some(count) = metadata.get(DATABLOCK_TOTAL_RECORDS) {
                             f64::from(count)
                         } else {
@@ -160,7 +160,7 @@ impl StreamProcessor<DataFrame> for CSVReader {
                             if index == num_files - 1 {
                                 // lineitem's cardinality estimate of 6_000_000 * SF is approximate.
                                 // For some scales, this value is smaller than 6_000_000 * SF.
-                                currect_total_records = expected_total_records;
+                                expected_total_records = currect_total_records;
                             }
                             if let Some(cardinality) = metadata.get_mut(DATABLOCK_CARDINALITY) {
                                 *cardinality = MetaCell::from(f64::min(1.0,

--- a/deepola/wake/src/polars_operations/reader/parquetreader.rs
+++ b/deepola/wake/src/polars_operations/reader/parquetreader.rs
@@ -91,7 +91,7 @@ impl StreamProcessor<DataFrame> for ParquetReader {
                 Payload::Signal(_) => break,
                 Payload::Some(dblock) => {
                     let mut metadata = dblock.metadata().clone();
-                    let expected_total_records =
+                    let mut expected_total_records =
                         if let Some(count) = metadata.get(DATABLOCK_TOTAL_RECORDS) {
                             f64::from(count)
                         } else {
@@ -114,7 +114,7 @@ impl StreamProcessor<DataFrame> for ParquetReader {
                             if index == num_files - 1 {
                                 // lineitem's cardinality estimate of 6_000_000 * SF is approximate.
                                 // For some scales, this value is smaller than 6_000_000 * SF.
-                                currect_total_records = expected_total_records;
+                                expected_total_records = currect_total_records;
                             }
                             if let Some(cardinality) = metadata.get_mut(DATABLOCK_CARDINALITY) {
                                 *cardinality = MetaCell::from(f64::min(1.0,

--- a/deepola/wake/src/polars_operations/reader/parquetreader.rs
+++ b/deepola/wake/src/polars_operations/reader/parquetreader.rs
@@ -103,13 +103,19 @@ impl StreamProcessor<DataFrame> for ParquetReader {
                         // This must be a length-one Polars series containing
                         // file names in its rows
                         let rows = series.utf8().unwrap();
+                        let num_files = rows.len();
 
                         // each file name produces multiple Series (each is a column)
-                        for filename in rows {
+                        for (index,filename) in rows.into_iter().enumerate() {
                             let output_df = self.dataframe_from_filename(filename.unwrap());
 
                             // Update record count
                             currect_total_records += output_df.height() as f64;
+                            if index == num_files - 1 {
+                                // lineitem's cardinality estimate of 6_000_000 * SF is approximate.
+                                // For some scales, this value is smaller than 6_000_000 * SF.
+                                currect_total_records = expected_total_records;
+                            }
                             if let Some(cardinality) = metadata.get_mut(DATABLOCK_CARDINALITY) {
                                 *cardinality = MetaCell::from(f64::min(1.0,
                                     currect_total_records / expected_total_records));


### PR DESCRIPTION
The cardinality of lineitem table as 6_000_000 * SF is approximate. For some scales, the actual cardinality is smaller than this value (by a very small number). Owing to this, the cardinality ratio in the last block is not 1.0 and hence the final result is still approximate (since scaling is performed).
Currently, fixed it by setting the cardinality of the last dataframe read to be 1.0.

Let me know if you have other suggestions!