### PR TITLE
Add option to specify latency or accuracy in expt

### DIFF
--- a/deepola/experiment.sh
+++ b/deepola/experiment.sh
@@ -7,9 +7,9 @@ int_handler() {
 }
 trap 'int_handler' INT
 
-if [ "$#" -ne 4 ]; then
-	echo "Expected 4 arguments, $# given."
-	echo "Usage: ./experiment.sh <data_dir> <scale-factor> <partition> <num-runs>"
+if [ "$#" -ne 5 ]; then
+	echo "Expected 5 arguments, $# given."
+	echo "Usage: ./experiment.sh <data_dir> <scale-factor> <partition> <num-runs> <start-run>"
 	exit
 fi
 
@@ -17,6 +17,7 @@ data_dir=$1
 scale=$2
 partition=$3
 num_runs=$4
+start_run=$5
 format=parquet
 
 # Build benchmark script
@@ -25,18 +26,23 @@ cargo build --release --example tpch_polars
 # The experiment loop
 for qdx in {1..22}
 do
-    for ((j = 0; j < ${num_runs}; j++))
+    for ((j = ${start_run}; j <= ${num_runs}; j++))
     do
-        echo ">>> ${qdx}, run= {$j}"
+	if [ $j -eq 0 ]; then
+		expt=accuracy
+	else
+		expt=latency
+	fi
+	echo ">>> ${qdx}, run= {$j}, expt= ${expt}"
 	expt_output_dir=saved-outputs/scale=${scale}/partition=${partition}/${format}/run=${j}
 	mkdir -p $expt_output_dir
 	echo "Evicting Cache"
 	vmtouch -e ${data_dir}/scale=${scale}/partition=${partition}/${format}
         query_output_dir=$expt_output_dir/q$qdx
         set -x
-        RUST_LOG=warn /usr/bin/time -f "$qdx,$j,%e,%M" ./target/release/examples/tpch_polars \
+        RUST_LOG=warn /usr/bin/time -f "$qdx,$j,$expt,%e,%M" ./target/release/examples/tpch_polars \
             query q${qdx} ${scale} \
-            ${data_dir}/scale=${scale}/partition=${partition}/${format} ${query_output_dir} 2>>$expt_output_dir/results.csv
+            ${data_dir}/scale=${scale}/partition=${partition}/${format} ${query_output_dir} ${expt} 2>>$expt_output_dir/results.csv
         set +x
     done
 done

--- a/deepola/experiment.sh
+++ b/deepola/experiment.sh
@@ -24,7 +24,7 @@ format=parquet
 cargo build --release --example tpch_polars
 
 # The experiment loop
-for qdx in {1..22}
+for qdx in {1..25}
 do
     for ((j = ${start_run}; j <= ${num_runs}; j++))
     do

--- a/deepola/wake/examples/tpch_polars/main.rs
+++ b/deepola/wake/examples/tpch_polars/main.rs
@@ -78,15 +78,20 @@ fn run_query(args: Vec<String>) {
         args[2].as_str()
     };
     let result_dir = if args.len() <= 3 {
-        format!("outputs/{query_no}")
+        format!("outputs/{}", query_no)
     } else {
-        args[3].to_string()
+        args[3].clone()
     };
-    log::warn!("Saving outputs in {}", result_dir);
+    let experiment = if args.len() <= 4 {
+        "latency"
+    } else {
+        args[4].as_str()
+    };
+    log::warn!("Saving outputs in {:?}", result_dir);
     let mut output_reader = NodeReader::empty();
     let mut query_service = get_query_service(query_no, scale, data_directory, &mut output_reader);
     log::info!("Running Query: {}", query_no);
-    utils::run_query(query_no, &mut query_service, &mut output_reader, result_dir);
+    utils::run_query(query_no, &mut query_service, &mut output_reader, result_dir, experiment);
 }
 
 pub fn get_query_service(

--- a/deepola/wake/examples/tpch_polars/utils.rs
+++ b/deepola/wake/examples/tpch_polars/utils.rs
@@ -139,21 +139,18 @@ pub fn run_query(
         }
         let data = message.datablock().data();
         let duration = Instant::now() - start_time;
-        match experiment {
-            "accuracy" => {
-                // Save the result dataframe
-                let file_path = results_dir_path.join(format!("{}.csv", epoch));
-                save_df_to_csv(&mut data.clone(), &file_path);
-                if epoch % 10 == 0 {
-                    log::warn!(
-                        "Query Result {} Took: {:.2?}",
-                        epoch + 1,
-                        duration
-                    );
-                }
-            },
-            "latency" => {},
-            _ => {panic!("Invalid experiment variation")}
+        if experiment == "accuracy" {
+            // Save the result dataframe
+            let file_path = results_dir_path.join(format!("{}.csv", epoch));
+            save_df_to_csv(&mut data.clone(), &file_path);
+            if epoch % 10 == 0 {
+                log::warn!(
+                    "Query Result {} Took: {:.2?}",
+                    epoch + 1,
+                    duration
+                );
+                log::warn!("Saved query result to {:?}", file_path);
+            }
         }
         query_result_time_ns.push(duration.as_nanos());
         last_df = data.clone();
@@ -167,6 +164,7 @@ pub fn run_query(
         log::warn!("Query Took: {:.2?}", end_time - start_time);
         let file_path = results_dir_path.join(format!("final.csv"));
         save_df_to_csv(&mut last_df, &file_path);
+        log::warn!("Saved final query result to {:?}", file_path);
         save_meta_result(&results_dir_path, &query_result_time_ns).expect("Failed to write meta result");
     } else {
         log::error!("Empty Query Result");

--- a/resources/tpc-h/queries/23.sql
+++ b/resources/tpc-h/queries/23.sql
@@ -1,0 +1,12 @@
+-- WanderJoin Query3
+select
+    sum(l_extendedprice * (1 - l_discount)) as revenue
+from
+    customer,
+    orders,
+    lineitem
+where
+    c_mktsegment = 'BUILDING'
+    and c_custkey = o_custkey
+    and l_orderkey = o_orderkey
+    and l_shipdate > date '1995-06-01'

--- a/resources/tpc-h/queries/24.sql
+++ b/resources/tpc-h/queries/24.sql
@@ -1,0 +1,10 @@
+-- WanderJoin Query10
+SELECT c_mktsegment, SUM(l_extendedprice * (1 - l_discount))
+FROM customer, lineitem, orders , nation
+WHERE c_custkey = o_custkey
+    AND	l_orderkey = o_orderkey
+    AND l_returnflag = 'R'
+    AND c_nationkey = n_nationkey
+    AND l_shipdate >= date '1994-05-04'
+    AND l_shipdate < date '1994-05-04' + interval '12' month
+GROUP BY c_mktsegment;

--- a/resources/tpc-h/queries/25.sql
+++ b/resources/tpc-h/queries/25.sql
@@ -1,0 +1,10 @@
+-- WanderJoin Query7
+SELECT sum(l_extendedprice * (1 - l_discount))
+FROM nation n1, supplier, lineitem, orders, customer, nation n2
+WHERE s_suppkey = l_suppkey
+    AND o_orderkey = l_orderkey
+    AND c_custkey = o_custkey
+    AND s_nationkey = n1.n_nationkey
+    AND c_nationkey = n2.n_nationkey
+    AND n1.n_name = 'CHINA'
+    AND l_shipdate > date '1994-05-01';

--- a/scripts/test-correctness.py
+++ b/scripts/test-correctness.py
@@ -1,0 +1,59 @@
+import os
+import sys
+import json
+import polars as pl
+
+def get_baseline_df(scale, variation, qdx):
+    answers_file = f"/data/DeepOLA/baselines/postgres/scale={scale}/variation={variation}/{qdx}.csv"
+    print(f">>> {qdx}, using baseline {answers_file}")
+    return pl.read_csv(answers_file)
+
+def get_obtained_df(scale, results_dir, qdx):
+    query_results_dir = os.path.join(results_dir, f"q{qdx}")
+    results_metadata = os.path.join(query_results_dir, "meta.json")
+    meta_data = json.loads(open(results_metadata,'r').read())
+    num_results = len(meta_data["time_measures_ns"])
+    last_result_file = f"{query_results_dir}/final.csv"
+    print(f">>> {qdx}, using obtained {last_result_file}")
+    return pl.read_csv(last_result_file)
+
+if __name__ == "__main__":
+    if len(sys.argv) <= 2:
+        print("Usage: python3 test-correctness.py <scale> <output-base-dir: path to directory containing qX folders> <optional: variation>")
+        exit(1)
+
+    scale = sys.argv[1]
+    results_dir = sys.argv[2]
+    variation = sys.argv[3] if len(sys.argv) >=4 else "data"
+
+    incorrect_queries = []
+    for qdx in range(1,23):
+        obtained_df = get_obtained_df(scale, results_dir, qdx)
+        baseline_df = get_baseline_df(scale, variation, qdx)
+
+        # To avoid failure due to incorrect column names
+        columns = baseline_df.columns
+        baseline_df.columns = columns
+        obtained_df.columns = columns
+
+        # Sort the dataframe: When order-by is defined on partial keys,
+        # the order of rows when these keys match is non-deterministic.
+        # Impacted Queries: Q3, Q10
+        obtained_df = obtained_df.sort(obtained_df.columns)
+        baseline_df = baseline_df.sort(baseline_df.columns)
+
+        # Strip the string values in the dataframe
+        obtained_df = obtained_df.with_columns([pl.col(pl.datatypes.Utf8).str.strip().keep_name()])
+        baseline_df = baseline_df.with_columns([pl.col(pl.datatypes.Utf8).str.strip().keep_name()])
+
+        # Compare the two dataframes
+        print(f"Comparing {qdx}")
+        try:
+            result = pl.testing.assert_frame_equal(baseline_df, obtained_df, check_dtype=False)
+            print(f"Correct Output on {qdx}")
+        except Exception as e:
+            print(e)
+            print(f"Incorrect Output on {qdx}")
+            incorrect_queries.append(qdx)
+
+    print(f"Incorrect Queries: {incorrect_queries}")

--- a/scripts/test-correctness.py
+++ b/scripts/test-correctness.py
@@ -27,9 +27,20 @@ if __name__ == "__main__":
     variation = sys.argv[3] if len(sys.argv) >=4 else "data"
 
     incorrect_queries = []
-    for qdx in range(1,23):
-        obtained_df = get_obtained_df(scale, results_dir, qdx)
-        baseline_df = get_baseline_df(scale, variation, qdx)
+    baseline_not_available = []
+    results_not_available = []
+    for qdx in range(1,26):
+        try:
+            obtained_df = get_obtained_df(scale, results_dir, qdx)
+        except:
+            results_not_available.append(qdx)
+            continue
+
+        try:
+            baseline_df = get_baseline_df(scale, variation, qdx)
+        except:
+            baseline_not_available.append(qdx)
+            continue
 
         # To avoid failure due to incorrect column names
         columns = baseline_df.columns
@@ -57,3 +68,5 @@ if __name__ == "__main__":
             incorrect_queries.append(qdx)
 
     print(f"Incorrect Queries: {incorrect_queries}")
+    print(f"Baseline not available: {baseline_not_available}")
+    print(f"Result not available: {results_not_available}")


### PR DESCRIPTION
- Latency Version: Only save time information to meta.json.
- Accuracy Version: Save the dataframe as soon as one is generated to avoid accumulating dataframes in memory. (Mainly for issues with Q10 and Q20 - large output dataframes)
- Both the versions also save a `final.csv` in the output directory - this can be used for final result.