### PR TITLE
Change from MM0 to MM1 + stabilize growth power fitting

### DIFF
--- a/deepola/experiment.sh
+++ b/deepola/experiment.sh
@@ -18,14 +18,18 @@ scale=$2
 partition=$3
 num_runs=$4
 start_run=$5
-format=parquet
 
 # Build benchmark script
 cargo build --release --example tpch_polars
 
 # The experiment loop
-for qdx in {1..25}
+for qdx in {1..27}
 do
+    if [ ${qdx} -eq 26 ] || [ ${qdx} -eq 27 ]; then
+	format=cleaned-parquet
+    else
+	format=parquet
+    fi
     for ((j = ${start_run}; j <= ${num_runs}; j++))
     do
 	if [ $j -eq 0 ]; then

--- a/deepola/experiment.sh
+++ b/deepola/experiment.sh
@@ -52,7 +52,7 @@ do
 
     if [ $j -ne 0 ]; then
         echo "Extracting accuracy at run= ${j}"
-        python3 ../scripts/extract_accuracy.py ${expt_output_dir} ${expt_output_dir_ref} ${qdx}
+        python3 ../scripts/extract_accuracy.py wake ${expt_output_dir} ${expt_output_dir_ref} ${qdx}
     fi
     done
 done

--- a/deepola/wake/examples/tpch_polars/main.rs
+++ b/deepola/wake/examples/tpch_polars/main.rs
@@ -22,11 +22,11 @@ mod q2;
 mod q20;
 mod q21;
 mod q22;
-mod q23;
-mod q24;
-mod q25;
-mod q26;
-mod q27;
+mod q23; // WanderJoin Q3
+mod q24; // WanderJoin Q10
+mod q25; // WanderJoin Q7
+mod q26; // ProgressiveDB Q1
+mod q27; // ProgressiveDB Q6
 mod q3;
 mod q4;
 mod q5;

--- a/deepola/wake/examples/tpch_polars/main.rs
+++ b/deepola/wake/examples/tpch_polars/main.rs
@@ -25,6 +25,8 @@ mod q22;
 mod q23;
 mod q24;
 mod q25;
+mod q26;
+mod q27;
 mod q3;
 mod q4;
 mod q5;
@@ -120,6 +122,8 @@ pub fn get_query_service(
         "q23" => q23::query(table_input, output_reader),
         "q24" => q24::query(table_input, output_reader),
         "q25" => q25::query(table_input, output_reader),
+        "q26" => q26::query(table_input, output_reader),
+        "q27" => q27::query(table_input, output_reader),
         "q3" => q3::query(table_input, output_reader),
         "q4" => q4::query(table_input, output_reader),
         "q5" => q5::query(table_input, output_reader),

--- a/deepola/wake/examples/tpch_polars/q24.rs
+++ b/deepola/wake/examples/tpch_polars/q24.rs
@@ -1,17 +1,15 @@
 use crate::prelude::*;
 
 /// WanderJoin's modified Q10.
-/// Refer: https://github.com/InitialDLab/XDB/blob/master/queries/query10_selection_groupby.sql
+/// Refer: https://github.com/InitialDLab/XDB/blob/master/queries/query10_online_groupby.sql
 /// This node implements the following SQL query
-// SELECT c_mktsegment, SUM(l_extendedprice * (1 - l_discount))
-// FROM customer, lineitem, orders , nation
-// WHERE c_custkey = o_custkey
-// 	AND	l_orderkey = o_orderkey
-// 	AND l_returnflag = 'R'
-// 	AND c_nationkey = n_nationkey
-// 	AND l_shipdate >= date '1994-05-04'
-// 	AND l_shipdate < date '1994-05-04' + interval '12' month
-// GROUP BY c_mktsegment;
+// SELECT ONLINE c_mktsegment, SUM(l_extendedprice * (1 - l_discount))
+// FROM customer, lineitem, orders, nation
+// WHERE   c_custkey = o_custkey
+//     AND l_orderkey = o_orderkey
+//     AND l_returnflag = 'R'
+//     AND c_nationkey = n_nationkey
+// GROUP BY c_mktsegment
 
 pub fn query(
     tableinput: HashMap<String, TableInput>,
@@ -58,11 +56,8 @@ pub fn query(
     // WHERE Node
     let lineitem_where_node = AppenderNode::<DataFrame, MapAppender>::new()
         .appender(MapAppender::new(Box::new(|df: &DataFrame| {
-            let var_date_1 = days_since_epoch(1994,5,4);
-            let var_date_2 = days_since_epoch(1995,5,4);
-            let l_shipdate = df.column("l_shipdate").unwrap();
             let l_returnflag = df.column("l_returnflag").unwrap();
-            let mask = l_shipdate.gt_eq(var_date_1).unwrap() & l_shipdate.lt(var_date_2).unwrap() & l_returnflag.equal("R").unwrap();
+            let mask = l_returnflag.equal("R").unwrap();
             df.filter(&mask).unwrap()
         })))
         .build();

--- a/deepola/wake/examples/tpch_polars/q26.rs
+++ b/deepola/wake/examples/tpch_polars/q26.rs
@@ -1,0 +1,172 @@
+use crate::prelude::*;
+
+/// Query Q1 of ProgressiveDB -- Same as Q1. Copied for convenience.
+/// This node implements the following SQL query
+// select
+// 	l_returnflag,
+// 	l_linestatus,
+// 	sum(l_quantity) as sum_qty,
+// 	sum(l_extendedprice) as sum_base_price,
+// 	sum(l_extendedprice * (1 - l_discount)) as sum_disc_price,
+// 	sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) as sum_charge,
+// 	avg(l_quantity) as avg_qty,
+// 	avg(l_extendedprice) as avg_price,
+// 	avg(l_discount) as avg_disc,
+// 	count(*) as count_order
+// from
+// 	lineitem
+// where
+// 	l_shipdate <= date '1998-12-01' - interval '90' day
+// group by
+// 	l_returnflag,
+// 	l_linestatus
+// order by
+// 	l_returnflag,
+// 	l_linestatus;
+// limit -1;
+
+pub fn query(
+    tableinput: HashMap<String, TableInput>,
+    output_reader: &mut NodeReader<polars::prelude::DataFrame>,
+) -> ExecutionService<polars::prelude::DataFrame> {
+    // Create a HashMap that stores table name and the columns in that query.
+    let table_columns = HashMap::from([(
+        "lineitem".into(),
+        vec![
+            "l_orderkey", // For COUNT(*) counting a key.
+            "l_quantity",
+            "l_extendedprice",
+            "l_discount",
+            "l_tax",
+            "l_returnflag",
+            "l_linestatus",
+            "l_shipdate",
+        ],
+    )]);
+
+    // CSVReaderNode would be created for this table.
+    let lineitem_csvreader_node = build_reader_node("lineitem".into(), &tableinput, &table_columns);
+
+    // WHERE Node
+    let where_node = AppenderNode::<DataFrame, MapAppender>::new()
+        .appender(MapAppender::new(Box::new(|df: &DataFrame| {
+            let var_date = days_since_epoch(1998,9,2);
+            let a = df.column("l_shipdate").unwrap();
+            let mask = a.lt_eq(var_date).unwrap();
+            df.filter(&mask).unwrap()
+        })))
+        .build();
+
+    // EXPRESSION Node
+    let expression_node = AppenderNode::<DataFrame, MapAppender>::new()
+        .appender(MapAppender::new(Box::new(|df: &DataFrame| {
+            let extended_price = df.column("l_extendedprice").unwrap();
+            let discount = df.column("l_discount").unwrap();
+            let tax = df.column("l_tax").unwrap();
+            let columns = vec![
+                Series::new(
+                    "disc_price",
+                    extended_price
+                        .cast(&polars::datatypes::DataType::Float64)
+                        .unwrap()
+                        * (discount * -1f64 + 1f64),
+                ),
+                Series::new(
+                    "charge",
+                    (extended_price
+                        .cast(&polars::datatypes::DataType::Float64)
+                        .unwrap()
+                        * (discount * -1f64 + 1f64))
+                        * (tax + 1f64),
+                ),
+            ];
+            df.hstack(&columns).unwrap()
+        })))
+        .build();
+
+    // GROUP BY Aggregate Node
+    let mut sum_accumulator = AggAccumulator::new();
+    sum_accumulator
+        .set_group_key(vec!["l_returnflag".to_string(), "l_linestatus".to_string()])
+        .set_aggregates(vec![
+            ("l_orderkey".into(), vec!["count".into()]),
+            ("l_quantity".into(), vec!["sum".into()]),
+            ("l_extendedprice".into(), vec!["sum".into()]),
+            ("l_discount".into(), vec!["sum".into()]),
+            ("disc_price".into(), vec!["sum".into()]),
+            ("charge".into(), vec!["sum".into()]),
+        ])
+        .set_scaler(AggregateScaler::new_growing()
+            .count_column("l_orderkey_count".into())
+            .scale_count("l_orderkey_count".into())
+            .scale_sum("l_quantity_sum".into())
+            .scale_sum("l_extendedprice_sum".into())
+            .scale_sum("l_discount_sum".into())
+            .scale_sum("disc_price_sum".into())
+            .scale_sum("charge_sum".into())
+            .into_rc()
+        );
+
+    let groupby_node = AccumulatorNode::<DataFrame, AggAccumulator>::new()
+        .accumulator(sum_accumulator)
+        .build();
+
+    // SELECT Node
+    let select_node = AppenderNode::<DataFrame, MapAppender>::new()
+        .appender(MapAppender::new(Box::new(|df: &DataFrame| {
+            // Compute AVG from SUM/COUNT.
+            let columns = vec![
+                Series::new("l_returnflag", df.column("l_returnflag").unwrap()),
+                Series::new("l_linestatus", df.column("l_linestatus").unwrap()),
+                Series::new("sum_qty", df.column("l_quantity_sum").unwrap()),
+                Series::new("sum_base_price", df.column("l_extendedprice_sum").unwrap()),
+                Series::new("sum_disc_price", df.column("disc_price_sum").unwrap()),
+                Series::new("sum_charge", df.column("charge_sum").unwrap()),
+                Series::new(
+                    "avg_qty",
+                    (df.column("l_quantity_sum")
+                        .unwrap()
+                        .cast(&polars::datatypes::DataType::Float64)
+                        .unwrap())
+                        / (df
+                            .column("l_orderkey_count")
+                            .unwrap()
+                            .cast(&polars::datatypes::DataType::Float64)
+                            .unwrap()),
+                ),
+                Series::new(
+                    "avg_price",
+                    df.column("l_extendedprice_sum").unwrap()
+                        / df.column("l_orderkey_count").unwrap(),
+                ),
+                Series::new(
+                    "avg_disc",
+                    df.column("l_discount_sum").unwrap() / df.column("l_orderkey_count").unwrap(),
+                ),
+                Series::new("count_order", df.column("l_orderkey_count").unwrap()),
+            ];
+            DataFrame::new(columns)
+                .unwrap()
+                .sort(&["l_returnflag", "l_linestatus"], vec![false, false])
+                .unwrap()
+        })))
+        .build();
+
+    // Connect nodes with subscription
+    where_node.subscribe_to_node(&lineitem_csvreader_node, 0);
+    expression_node.subscribe_to_node(&where_node, 0);
+    groupby_node.subscribe_to_node(&expression_node, 0);
+    select_node.subscribe_to_node(&groupby_node, 0);
+
+    // Output reader subscribe to output node.
+    output_reader.subscribe_to_node(&select_node, 0);
+
+    // Add all the nodes to the service
+    let mut service = ExecutionService::<polars::prelude::DataFrame>::create();
+    service.add(select_node);
+    service.add(groupby_node);
+    service.add(expression_node);
+    service.add(where_node);
+    service.add(lineitem_csvreader_node);
+    service
+}

--- a/deepola/wake/examples/tpch_polars/q27.rs
+++ b/deepola/wake/examples/tpch_polars/q27.rs
@@ -1,0 +1,84 @@
+use crate::prelude::*;
+
+/// Query Q6 of ProgressiveDB; Since ProgressiveDB uses integer, changed l_discount where.
+/// This node implements the following SQL query
+// select
+// 	sum(l_extendedprice * l_discount) as revenue
+// from
+// 	lineitem
+// where
+// 	l_shipdate >= date '1994-01-01'
+// 	and l_shipdate < date '1994-01-01' + interval '1' year
+// 	and l_discount between 5 and 7
+// 	and l_quantity < 24;
+
+pub fn query(
+    tableinput: HashMap<String, TableInput>,
+    output_reader: &mut NodeReader<polars::prelude::DataFrame>,
+) -> ExecutionService<polars::prelude::DataFrame> {
+    // Create a HashMap that stores table name and the columns in that query.
+    let table_columns = HashMap::from([(
+        "lineitem".into(),
+        vec!["l_quantity", "l_extendedprice", "l_discount", "l_shipdate"],
+    )]);
+
+    // CSVReaderNode would be created for this table.
+    let lineitem_csvreader_node = build_reader_node("lineitem".into(), &tableinput, &table_columns);
+
+    // WHERE Node
+    let where_node = AppenderNode::<DataFrame, MapAppender>::new()
+        .appender(MapAppender::new(Box::new(|df: &DataFrame| {
+            let l_shipdate = df.column("l_shipdate").unwrap();
+            let l_discount = df.column("l_discount").unwrap();
+            let l_quantity = df.column("l_quantity").unwrap();
+            let var_date_1 = days_since_epoch(1994,1,1);
+            let var_date_2 = days_since_epoch(1995,1,1);
+            let mask = l_shipdate.gt_eq(var_date_1).unwrap()
+                & l_shipdate.lt(var_date_2).unwrap()
+                & l_discount.gt_eq(5).unwrap()
+                & l_discount.lt_eq(7).unwrap()
+                & l_quantity.lt(24).unwrap();
+            df.filter(&mask).unwrap()
+        })))
+        .build();
+
+    // EXPRESSION Node
+    let expression_node = AppenderNode::<DataFrame, MapAppender>::new()
+        .appender(MapAppender::new(Box::new(|df: &DataFrame| {
+            let extended_price = df.column("l_extendedprice").unwrap();
+            let discount = df.column("l_discount").unwrap();
+            let columns = vec![Series::new("disc_price", extended_price * discount)];
+            DataFrame::new(columns).unwrap()
+        })))
+        .build();
+
+    // GROUP BY Aggregate Node
+    let mut agg_accumulator = AggAccumulator::new();
+    agg_accumulator
+        .set_aggregates(vec![("disc_price".into(), vec!["sum".into()])])
+        .set_add_count_column(true)
+        .set_scaler(AggregateScaler::new_growing()
+            .remove_count_column()  // Remove added group count column
+            .scale_sum("disc_price_sum".into())
+            .into_rc()
+        );
+    let groupby_node = AccumulatorNode::<DataFrame, AggAccumulator>::new()
+        .accumulator(agg_accumulator)
+        .build();
+
+    // Connect nodes with subscription
+    where_node.subscribe_to_node(&lineitem_csvreader_node, 0);
+    expression_node.subscribe_to_node(&where_node, 0);
+    groupby_node.subscribe_to_node(&expression_node, 0);
+
+    // Output reader subscribe to output node.
+    output_reader.subscribe_to_node(&groupby_node, 0);
+
+    // Add all the nodes to the service
+    let mut service = ExecutionService::<polars::prelude::DataFrame>::create();
+    service.add(groupby_node);
+    service.add(expression_node);
+    service.add(where_node);
+    service.add(lineitem_csvreader_node);
+    service
+}

--- a/deepola/wake/src/forecast/cell.rs
+++ b/deepola/wake/src/forecast/cell.rs
@@ -248,6 +248,17 @@ impl LeastSquareAffineEstimator {
         let intercept = self.mean_v - slope * self.mean_t;
         AffineForecast::new(slope, intercept)
     }
+
+    pub fn slope(&self) -> f64 {
+        if self.var_t == 0.0 {
+            return 0.0
+        }
+        self.cov_tv / self.var_t  // (X^T X)^{-1} X^T Y
+    }
+
+    pub fn intercept(&self) -> f64 {
+        self.mean_v - self.slope() * self.mean_t
+    }
 }
 
 impl CellConsumer for LeastSquareAffineEstimator {

--- a/deepola/wake/src/forecast/mod.rs
+++ b/deepola/wake/src/forecast/mod.rs
@@ -81,5 +81,5 @@ impl<'a> Iterator for SeriesIter<'a> {
 
 pub mod cell;
 pub mod row;
-pub mod table;
+// pub mod table;
 pub mod score;

--- a/deepola/wake/src/inference/count.rs
+++ b/deepola/wake/src/inference/count.rs
@@ -1,0 +1,65 @@
+use std::cell::RefCell;
+
+use crate::forecast::cell::CellConsumer;
+use crate::forecast::cell::LeastSquareAffineEstimator;
+use crate::forecast::TimeValue;
+
+
+/// Estimate cardinality given progress so far
+pub struct PowerCardinalityEstimator {
+    power: RefCell<f64>,
+
+    /// Estimate power to the mean count
+    power_estimator: RefCell<LeastSquareAffineEstimator>,
+}
+
+
+impl PowerCardinalityEstimator {
+    pub fn constant() -> PowerCardinalityEstimator {
+        PowerCardinalityEstimator {
+            power: RefCell::new(0.0),
+            power_estimator: RefCell::new(LeastSquareAffineEstimator::default()),
+        }
+    }
+
+    pub fn with_power(power: f64) -> PowerCardinalityEstimator {
+        assert!((0.0..=1.0).contains(&power));
+        PowerCardinalityEstimator {
+            power: RefCell::new(power),
+            power_estimator: RefCell::new(LeastSquareAffineEstimator::default()),
+        }
+    }
+
+    pub fn linear() -> PowerCardinalityEstimator {
+        PowerCardinalityEstimator {
+            power: RefCell::new(1.0),
+            power_estimator: RefCell::new(LeastSquareAffineEstimator::default()),
+        }
+    }
+
+    pub fn estimate(&self, count: f64, fraction: f64) -> f64 {
+        assert!((0.0..=1.0).contains(&fraction));
+        if *self.power.borrow() == 0.0 || fraction == 0.0 {
+            count
+        } else {
+            (count / fraction.powf(*self.power.borrow())).round()
+        }
+    }
+
+    pub fn update_power(&self, total_count: f64, group_count: f64, fraction: f64) {
+        let new_power = {
+            let mut power_estimator = self.power_estimator.borrow_mut();
+            let count = total_count / group_count;  // Average group cardinality.
+            let log_count = count.ln();
+            let log_fraction = fraction.ln();
+            power_estimator.consume(&TimeValue { t: log_fraction, v: log_count });
+            // log::error!("count_mean= {:.2}, fraction= {:.2}: slope= {:.2}, intercept= {:.2}", count, fraction, power_estimator.slope(), power_estimator.intercept());
+            power_estimator.slope()
+        };
+        self.set_power(new_power)
+    }
+
+    fn set_power(&self, power: f64) {
+        *self.power.borrow_mut() = power;
+    }
+}

--- a/deepola/wake/src/inference/mod.rs
+++ b/deepola/wake/src/inference/mod.rs
@@ -1,3 +1,4 @@
+mod count;
 mod count_distinct;
 mod scaler;
 

--- a/deepola/wake/src/lib.rs
+++ b/deepola/wake/src/lib.rs
@@ -4,7 +4,7 @@ pub mod graph;
 pub mod inference;
 pub mod polars_operations;
 pub mod processor;
-// pub mod forecast;
+pub mod forecast;
 
 #[cfg(test)]
 mod tests {

--- a/deepola/wake/src/polars_operations/accumulator/agg_accumulator.rs
+++ b/deepola/wake/src/polars_operations/accumulator/agg_accumulator.rs
@@ -79,9 +79,10 @@ impl AggAccumulator {
         // Add a column with value 0 to support both empty and non-empty groupby key with same syntax and column name mechanism.
         let num_of_rows = df.height();
         let mut raw_df = df
-            .hstack(&[Series::new(DEFAULT_GROUPBY_KEY, vec![0; num_of_rows])])
-            .unwrap()
-            .hstack(&[Series::new(DEFAULT_GROUP_COLUMN, vec![0; num_of_rows])])
+            .hstack(&[
+                Series::new(DEFAULT_GROUPBY_KEY, vec![0; num_of_rows]),
+                Series::new(DEFAULT_GROUP_COLUMN, vec![0; num_of_rows]),
+            ])
             .unwrap();
 
         // Arrow raises an error if the Chunks gets misaligned.

--- a/scripts/extract_accuracy.py
+++ b/scripts/extract_accuracy.py
@@ -6,7 +6,7 @@ import json
 import numpy as np
 import pandas as pd
 
-from scipy.special import gamma
+# from scipy.special import gamma
 
 
 # Groupby columns for each query

--- a/scripts/extract_accuracy.py
+++ b/scripts/extract_accuracy.py
@@ -36,6 +36,8 @@ on_dict = {
     23: [],
     24: ["c_mktsegment"],
     25: [],
+    26: ["l_returnflag", "l_linestatus"],
+    27: [],
 }
 
 def read_dir(q_idx, dirpath):

--- a/scripts/merge_accuracy.py
+++ b/scripts/merge_accuracy.py
@@ -1,7 +1,7 @@
 """
-Example: merging across 10 runs over all 25 queries and name table with prefix fooHundred.
+Example: merging across 10 runs over all 27 queries and name table with prefix fooHundred.
 
-    for qidx in {1..25}; do \
+    for qidx in {1..27}; do \
         python scripts/merge_accuracy.py \
             deepola/wake/saved-vanilla/scale\=100/partition\=512M/parquet \
             1 10 ${qidx} ./merged.txt --latex_name fooHundred; \

--- a/scripts/test-correctness.py
+++ b/scripts/test-correctness.py
@@ -29,7 +29,7 @@ if __name__ == "__main__":
     incorrect_queries = []
     baseline_not_available = []
     results_not_available = []
-    for qdx in range(1,26):
+    for qdx in range(1,27):
         try:
             obtained_df = get_obtained_df(scale, results_dir, qdx)
         except:


### PR DESCRIPTION
MM1 to MM0
- MM0 assumes an infinite-sample population, while MM1 uses the estimated cardinality to estimate with a finite-sample population
- Turns out gamma and digamma are moderately cheap to evaluate


Growth power fitting
- Move cardinality estimator out into a separate mod
- Fit power using log-transformed online OLS by default when apply scaler