### PR TITLE
Augment aggregate with variance for CI and add depth experiments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,12 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+
+# Ignore experiment outputs
+**/saved*/**/*.txt
+**/saved*/**/*.json
+**/output*/**/*.json
+**/progressive/**/*.json
+**/progressive/**/*.txt
+**/numbertable.*

--- a/deepola/experiment_ci.sh
+++ b/deepola/experiment_ci.sh
@@ -1,0 +1,46 @@
+#/!bin/bash
+
+int_handler() {
+    echo "Interrupted."
+    kill $PPID
+    exit 1
+}
+trap 'int_handler' INT
+
+if [ "$#" -ne 5 ]; then
+    echo "Expected 5 arguments, $# given."
+    echo "Usage: ./experiment.sh <data_dir> <scale-factor> <partition> <num-runs> <start-run>"
+    exit
+fi
+
+data_dir=$1
+scale=$2
+partition=$3
+num_runs=$4
+start_run=$5
+
+# qdx=1c
+# qdx=6c
+qdx=14c
+expt=accuracy
+# format=tbl
+format=parquet
+
+# Build benchmark script
+cargo build --release --example tpch_polars
+
+# The experiment loop
+for ((j = ${start_run}; j <= ${num_runs}; j++)) do
+    echo ">>> ${qdx}, run= ${j}, expt= ${expt}"
+    expt_output_dir=saved-outputs/scale=${scale}/partition=${partition}/${format}/run=${j}
+    expt_output_dir_ref=saved-outputs/scale=${scale}/partition=${partition}/${format}/run=0
+    mkdir -p $expt_output_dir
+    echo "Evicting Cache"
+    # vmtouch -e ${data_dir}/scale=${scale}/partition=${partition}/${format}
+    query_output_dir=$expt_output_dir/q$qdx
+    set -x
+    RUST_LOG=warn ./target/release/examples/tpch_polars \
+        query q${qdx} ${scale} \
+        ${data_dir}/scale=${scale}/partition=${partition}/${format} ${query_output_dir} ${expt} # 2>>$expt_output_dir/results.csv
+    set +xh
+done

--- a/deepola/experiment_depth.sh
+++ b/deepola/experiment_depth.sh
@@ -1,0 +1,56 @@
+#/!bin/bash
+
+int_handler() {
+    echo "Interrupted."
+    kill $PPID
+    exit 1
+}
+trap 'int_handler' INT
+
+if [ "$#" -ne 3 ]; then
+    echo "Expected 3 arguments, $# given."
+    echo "Usage: ./experiment.sh <data_dir> <num-runs> <start-run>"
+    exit
+fi
+
+data_dir=$1
+num_runs=$2
+start_run=$3
+
+data_params=g10_p1m_n100_c4
+qdx=30
+expt=accuracy
+format=parquet
+scale=100
+
+# Build benchmark script
+cargo build --release --example tpch_polars
+
+# The experiment loop
+for depth in {0..10}; do
+    for ((j = ${start_run}; j <= ${num_runs}; j++)) do
+        if [ $j -eq 0 ]; then
+            expt=accuracy
+        else
+            expt=latency
+        fi
+        echo ">>> ${qdx}, depth= ${depth}, run= ${j}, expt= ${expt}"
+        expt_data_dir=${data_dir}/${data_params}/${format}
+        expt_output_dir=saved-outputs/${data_params}/depth=${depth}/run=${j}
+        expt_output_dir_ref=saved-outputs/${data_params}/depth=${depth}/run=0
+        mkdir -p $expt_output_dir
+        echo "Evicting Cache"
+        vmtouch -e ${expt_data_dir}
+        query_output_dir=$expt_output_dir/q$qdx
+        set -x
+        RUST_LOG=warn QUERY_DEPTH=${depth} ./target/release/examples/tpch_polars \
+            query q${qdx} ${scale} \
+            ${expt_data_dir} ${query_output_dir} ${expt} # 2>>$expt_output_dir/results.csv
+        set +xh
+
+        if [ $j -ne 0 ]; then
+            echo "Extracting accuracy at run= ${j}"
+            python3 ../scripts/extract_accuracy.py wake ${expt_output_dir} ${expt_output_dir_ref} ${qdx}
+        fi
+    done
+done

--- a/deepola/wake/examples/tpch_polars/main.rs
+++ b/deepola/wake/examples/tpch_polars/main.rs
@@ -8,11 +8,13 @@ use std::env;
 use wake::graph::*;
 
 mod q1;
+mod q1c;
 mod q10;
 mod q11;
 mod q12;
 mod q13;
 mod q14;
+mod q14c;
 mod q15;
 mod q16;
 mod q17;
@@ -30,9 +32,12 @@ mod q27; // ProgressiveDB Q6
 mod q3;
 mod q4;
 mod q5;
+mod q5c;
 mod q6;
+mod q6c;
 mod q7;
 mod q8;
+mod q8c;
 mod q9;
 mod prelude;
 mod utils;
@@ -105,11 +110,13 @@ pub fn get_query_service(
     let table_input = utils::load_tables(data_directory, scale);
     let query_service = match query_no {
         "q1" => q1::query(table_input, output_reader),
+        "q1c" => q1c::query(table_input, output_reader),
         "q10" => q10::query(table_input, output_reader),
         "q11" => q11::query(table_input, output_reader),
         "q12" => q12::query(table_input, output_reader),
         "q13" => q13::query(table_input, output_reader),
         "q14" => q14::query(table_input, output_reader),
+        "q14c" => q14c::query(table_input, output_reader),
         "q15" => q15::query(table_input, output_reader),
         "q16" => q16::query(table_input, output_reader),
         "q17" => q17::query(table_input, output_reader),
@@ -127,9 +134,12 @@ pub fn get_query_service(
         "q3" => q3::query(table_input, output_reader),
         "q4" => q4::query(table_input, output_reader),
         "q5" => q5::query(table_input, output_reader),
+        "q5c" => q5c::query(table_input, output_reader),
         "q6" => q6::query(table_input, output_reader),
+        "q6c" => q6c::query(table_input, output_reader),
         "q7" => q7::query(table_input, output_reader),
         "q8" => q8::query(table_input, output_reader),
+        "q8c" => q8c::query(table_input, output_reader),
         "q9" => q9::query(table_input, output_reader),
         _ => panic!("Invalid Query Parameter"),
     };

--- a/deepola/wake/examples/tpch_polars/main.rs
+++ b/deepola/wake/examples/tpch_polars/main.rs
@@ -30,6 +30,7 @@ mod q25; // WanderJoin Q7
 mod q26; // ProgressiveDB Q1
 mod q27; // ProgressiveDB Q6
 mod q3;
+mod q30; // Deep query with variable depth
 mod q4;
 mod q5;
 mod q5c;
@@ -107,7 +108,8 @@ pub fn get_query_service(
     data_directory: &str,
     output_reader: &mut NodeReader<DataFrame>,
 ) -> ExecutionService<DataFrame> {
-    let table_input = utils::load_tables(data_directory, scale);
+    let use_numbertable = query_no == "q30";
+    let table_input = utils::load_tables(data_directory, scale, use_numbertable);
     let query_service = match query_no {
         "q1" => q1::query(table_input, output_reader),
         "q1c" => q1c::query(table_input, output_reader),
@@ -132,6 +134,11 @@ pub fn get_query_service(
         "q26" => q26::query(table_input, output_reader),
         "q27" => q27::query(table_input, output_reader),
         "q3" => q3::query(table_input, output_reader),
+        "q30" => {
+            let query_depth = std::env::var("QUERY_DEPTH").expect("Set env variable QUERY_DEPTH");
+            let query_depth: usize = query_depth.parse().expect("Expect integer QUERY_DEPTH");
+            q30::query(table_input, output_reader, query_depth)
+        },
         "q4" => q4::query(table_input, output_reader),
         "q5" => q5::query(table_input, output_reader),
         "q5c" => q5c::query(table_input, output_reader),

--- a/deepola/wake/examples/tpch_polars/q14c.rs
+++ b/deepola/wake/examples/tpch_polars/q14c.rs
@@ -1,0 +1,155 @@
+use crate::prelude::*;
+
+/// This node implements the following SQL query
+// select
+//  100.00 * sum(case
+//      when p_type like 'PROMO%'
+//          then l_extendedprice * (1 - l_discount)
+//      else 0
+//  end) / sum(l_extendedprice * (1 - l_discount)) as promo_revenue
+// from
+//  lineitem,
+//  part
+// where
+//  l_partkey = p_partkey
+//  and l_shipdate >= date '1995-09-01'
+//  and l_shipdate < date '1995-09-01' + interval '1' month;
+
+pub fn query(
+    tableinput: HashMap<String, TableInput>,
+    output_reader: &mut NodeReader<polars::prelude::DataFrame>,
+) -> ExecutionService<polars::prelude::DataFrame> {
+    // Create a HashMap that stores table name and the columns in that query.
+    let table_columns = HashMap::from([
+        (
+            "lineitem".into(),
+            vec!["l_partkey", "l_extendedprice", "l_discount", "l_shipdate"],
+        ),
+        ("part".into(), vec!["p_partkey", "p_type"]),
+    ]);
+
+    // CSVReaderNode would be created for this table.
+    let lineitem_csvreader_node = build_reader_node_permute_files("lineitem".into(), &tableinput, &table_columns);
+    let part_csvreader_node = build_reader_node_permute_files("part".into(), &tableinput, &table_columns);
+
+    // WHERE Node
+    let where_node = AppenderNode::<DataFrame, MapAppender>::new()
+        .appender(MapAppender::new(Box::new(|df: &DataFrame| {
+            let a = df.column("l_shipdate").unwrap();
+            let var_date_1 = days_since_epoch(1995,9,1);
+            let var_date_2 = days_since_epoch(1995,10,1);
+            let mask = a.gt_eq(var_date_1).unwrap() & a.lt(var_date_2).unwrap();
+            df.filter(&mask).unwrap()
+        })))
+        .build();
+
+    // HASH JOIN Node
+    let hash_join_node = HashJoinBuilder::new()
+        .left_on(vec!["l_partkey".into()])
+        .right_on(vec!["p_partkey".into()])
+        .build();
+
+    // EXPRESSION Node
+    let expression_node = AppenderNode::<DataFrame, MapAppender>::new()
+        .appender(MapAppender::new(Box::new(|df: &DataFrame| {
+            let a = df.column("p_type").unwrap();
+            let mask = a
+                .utf8()
+                .unwrap()
+                .into_iter()
+                .map(|x| x.unwrap().starts_with("PROMO") as i32)
+                .collect_vec();
+            let extended_price = df.column("l_extendedprice").unwrap();
+            let discount = df.column("l_discount").unwrap();
+            let columns = vec![
+                Series::new(
+                    "denominator_promo_revenue",
+                    extended_price
+                        .cast(&polars::datatypes::DataType::Float64)
+                        .unwrap()
+                        * (discount * -1f64 + 1f64),
+                ),
+                Series::new(
+                    "numerator_promo_revenue",
+                    extended_price
+                        .cast(&polars::datatypes::DataType::Float64)
+                        .unwrap()
+                        * (discount * -1f64 + 1f64)
+                        * Series::new("promo", &mask),
+                ),
+            ];
+            df.hstack(&columns).unwrap()
+        })))
+        .build();
+
+    // AGGREGATE Node
+    let mut agg_accumulator = AggAccumulator::new();
+    agg_accumulator
+        .set_aggregates(vec![
+            ("numerator_promo_revenue".into(), vec!["sum".into()]),
+            ("denominator_promo_revenue".into(), vec!["sum".into()]),
+        ])
+        .set_add_count_column(true)
+        .set_track_variance(true)
+        .set_scaler(AggregateScaler::new_growing()
+            .remove_count_column()  // Remove added group count column
+            .track_variance()
+            .scale_sum_with_variance(
+                "numerator_promo_revenue_sum".into(),
+                "numerator_promo_revenue_var".into()
+            )
+            .scale_sum_with_variance(
+                "denominator_promo_revenue_sum".into(),
+                "denominator_promo_revenue_var".into()
+            )
+            .track_sum_sum_covariance(
+                "numerator_promo_revenue_sum".into(),
+                "denominator_promo_revenue_sum".into()
+            )
+            .into_rc()
+        );
+    let groupby_node = AccumulatorNode::<DataFrame, AggAccumulator>::new()
+        .accumulator(agg_accumulator)
+        .build();
+
+    // SELECT Node
+    let select_node = AppenderNode::<DataFrame, MapAppender>::new()
+        .appender(MapAppender::new(Box::new(|df: &DataFrame| {
+            let num = df.column("numerator_promo_revenue_sum").unwrap();
+            let den = df.column("denominator_promo_revenue_sum").unwrap();
+            let res = Series::new("promo_revenue", (num / den) * 100f64);
+            let num_var = df.column("numerator_promo_revenue_sum_var").unwrap();
+            let den_var = df.column("denominator_promo_revenue_sum_var").unwrap();
+            let num_den_cov = df.column(
+                "numerator_promo_revenue_sum_denominator_promo_revenue_sum_cov"
+            ).unwrap();
+            let res_var = Series::new(
+                "promo_revenue_var",
+                calculate_div_var(num, num_var, den, den_var, num_den_cov, &res)
+            );
+            DataFrame::new(vec![res, res_var]).unwrap()
+        })))
+        .build();
+
+    // Connect nodes with subscription
+    where_node.subscribe_to_node(&lineitem_csvreader_node, 0);
+    hash_join_node.subscribe_to_node(&where_node, 0); // Left Node
+    hash_join_node.subscribe_to_node(&part_csvreader_node, 1); // Right Node
+    expression_node.subscribe_to_node(&hash_join_node, 0);
+    groupby_node.subscribe_to_node(&expression_node, 0);
+    select_node.subscribe_to_node(&groupby_node, 0);
+
+    // Output reader subscribe to output node.
+    output_reader.subscribe_to_node(&select_node, 0);
+
+    // Add all the nodes to the service
+    let mut service = ExecutionService::<polars::prelude::DataFrame>::create();
+    service.add(lineitem_csvreader_node);
+    service.add(where_node);
+    service.add(part_csvreader_node);
+    service.add(hash_join_node);
+    service.add(expression_node);
+    service.add(groupby_node);
+    service.add(select_node);
+    service
+}

--- a/deepola/wake/examples/tpch_polars/q1c.rs
+++ b/deepola/wake/examples/tpch_polars/q1c.rs
@@ -1,0 +1,215 @@
+use crate::prelude::*;
+
+/// This node implements the following SQL query
+// select
+//  l_returnflag,
+//  l_linestatus,
+//  sum(l_quantity) as sum_qty,
+//  sum(l_extendedprice) as sum_base_price,
+//  sum(l_extendedprice * (1 - l_discount)) as sum_disc_price,
+//  sum(l_extendedprice * (1 - l_discount) * (1 + l_tax)) as sum_charge,
+//  avg(l_quantity) as avg_qty,
+//  avg(l_extendedprice) as avg_price,
+//  avg(l_discount) as avg_disc,
+//  count(*) as count_order
+// from
+//  lineitem
+// where
+//  l_shipdate <= date '1998-12-01' - interval '90' day
+// group by
+//  l_returnflag,
+//  l_linestatus
+// order by
+//  l_returnflag,
+//  l_linestatus;
+// limit -1;
+
+pub fn query(
+    tableinput: HashMap<String, TableInput>,
+    output_reader: &mut NodeReader<polars::prelude::DataFrame>,
+) -> ExecutionService<polars::prelude::DataFrame> {
+    // Create a HashMap that stores table name and the columns in that query.
+    let table_columns = HashMap::from([(
+        "lineitem".into(),
+        vec![
+            "l_orderkey", // For COUNT(*) counting a key.
+            "l_quantity",
+            "l_extendedprice",
+            "l_discount",
+            "l_tax",
+            "l_returnflag",
+            "l_linestatus",
+            "l_shipdate",
+        ],
+    )]);
+
+    // CSVReaderNode would be created for this table.
+    let lineitem_csvreader_node = build_reader_node_permute_files("lineitem".into(), &tableinput, &table_columns);
+
+    // WHERE Node
+    let where_node = AppenderNode::<DataFrame, MapAppender>::new()
+        .appender(MapAppender::new(Box::new(|df: &DataFrame| {
+            let var_date = days_since_epoch(1998,9,2);
+            let a = df.column("l_shipdate").unwrap();
+            let mask = a.lt_eq(var_date).unwrap();
+            df.filter(&mask).unwrap()
+        })))
+        .build();
+
+    // EXPRESSION Node
+    let expression_node = AppenderNode::<DataFrame, MapAppender>::new()
+        .appender(MapAppender::new(Box::new(|df: &DataFrame| {
+            let extended_price = df.column("l_extendedprice").unwrap();
+            let discount = df.column("l_discount").unwrap();
+            let tax = df.column("l_tax").unwrap();
+            let columns = vec![
+                Series::new(
+                    "disc_price",
+                    extended_price
+                        .cast(&polars::datatypes::DataType::Float64)
+                        .unwrap()
+                        * (discount * -1f64 + 1f64),
+                ),
+                Series::new(
+                    "charge",
+                    (extended_price
+                        .cast(&polars::datatypes::DataType::Float64)
+                        .unwrap()
+                        * (discount * -1f64 + 1f64))
+                        * (tax + 1f64),
+                ),
+            ];
+            df.hstack(&columns).unwrap()
+        })))
+        .build();
+
+    // GROUP BY Aggregate Node
+    let mut sum_accumulator = AggAccumulator::new();
+    sum_accumulator
+        .set_group_key(vec!["l_returnflag".to_string(), "l_linestatus".to_string()])
+        .set_aggregates(vec![
+            ("l_orderkey".into(), vec!["count".into()]),
+            ("l_quantity".into(), vec!["sum".into()]),
+            ("l_extendedprice".into(), vec!["sum".into()]),
+            ("l_discount".into(), vec!["sum".into()]),
+            ("disc_price".into(), vec!["sum".into()]),
+            ("charge".into(), vec!["sum".into()]),
+        ])
+        .set_track_variance(true)
+        .set_scaler(AggregateScaler::new_growing()
+            .count_column("l_orderkey_count".into())
+            .track_variance()
+            .scale_count_with_variance("l_orderkey_count".into())
+            .scale_sum_with_variance("l_quantity_sum".into(), "l_quantity_var".into())
+            .scale_sum_with_variance("l_extendedprice_sum".into(), "l_extendedprice_var".into())
+            .scale_sum_with_variance("l_discount_sum".into(), "l_discount_var".into())
+            .scale_sum_with_variance("disc_price_sum".into(), "disc_price_var".into())
+            .scale_sum_with_variance("charge_sum".into(), "charge_var".into())
+            .track_sum_sum_covariance("l_quantity_sum".into(), "l_orderkey_count".into())
+            .track_sum_sum_covariance("l_extendedprice_sum".into(), "l_orderkey_count".into())
+            .track_sum_sum_covariance("l_discount_sum".into(), "l_orderkey_count".into())
+            .into_rc()
+        );
+
+    let groupby_node = AccumulatorNode::<DataFrame, AggAccumulator>::new()
+        .accumulator(sum_accumulator)
+        .build();
+
+    // SELECT Node
+    let select_node = AppenderNode::<DataFrame, MapAppender>::new()
+        .appender(MapAppender::new(Box::new(|df: &DataFrame| {
+            // Compute AVG from SUM/COUNT.
+            let avg_qty = Series::new(
+                "avg_qty",
+                (df.column("l_quantity_sum")
+                    .unwrap()
+                    .cast(&polars::datatypes::DataType::Float64)
+                    .unwrap())
+                    / (df
+                        .column("l_orderkey_count")
+                        .unwrap()
+                        .cast(&polars::datatypes::DataType::Float64)
+                        .unwrap()),
+            );
+            let avg_price = Series::new(
+                "avg_price",
+                df.column("l_extendedprice_sum").unwrap()
+                    / df.column("l_orderkey_count").unwrap(),
+            );
+            let avg_disc = Series::new(
+                "avg_disc",
+                df.column("l_discount_sum").unwrap() / df.column("l_orderkey_count").unwrap(),
+            );
+            let columns = vec![
+                Series::new("l_returnflag", df.column("l_returnflag").unwrap()),
+                Series::new("l_linestatus", df.column("l_linestatus").unwrap()),
+                Series::new("sum_qty", df.column("l_quantity_sum").unwrap()),
+                Series::new("sum_base_price", df.column("l_extendedprice_sum").unwrap()),
+                Series::new("sum_disc_price", df.column("disc_price_sum").unwrap()),
+                Series::new("sum_charge", df.column("charge_sum").unwrap()),
+                Series::new("count_order", df.column("l_orderkey_count").unwrap()),
+
+                Series::new("sum_qty_var", df.column("l_quantity_sum_var").unwrap()),
+                Series::new("sum_base_price_var", df.column("l_extendedprice_sum_var").unwrap()),
+                Series::new("sum_disc_price_var", df.column("disc_price_sum_var").unwrap()),
+                Series::new("sum_charge_var", df.column("charge_sum_var").unwrap()),
+                Series::new(
+                    "avg_qty_var",
+                    calculate_div_var(
+                        &df.column("l_quantity_sum").unwrap().cast(&polars::datatypes::DataType::Float64).unwrap(),
+                        df.column("l_quantity_sum_var").unwrap(),
+                        &df.column("l_orderkey_count").unwrap().cast(&polars::datatypes::DataType::Float64).unwrap(),
+                        df.column("l_orderkey_count_var").unwrap(),
+                        df.column("l_quantity_sum_l_orderkey_count_cov").unwrap(),
+                        &avg_qty
+                    )
+                ),
+                Series::new(
+                    "avg_price_var",
+                    calculate_div_var(
+                        &df.column("l_extendedprice_sum").unwrap().cast(&polars::datatypes::DataType::Float64).unwrap(),
+                        df.column("l_extendedprice_sum_var").unwrap(),
+                        &df.column("l_orderkey_count").unwrap().cast(&polars::datatypes::DataType::Float64).unwrap(),
+                        df.column("l_orderkey_count_var").unwrap(),
+                        df.column("l_extendedprice_sum_l_orderkey_count_cov").unwrap(),
+                        &avg_price
+                    )
+                ),
+                Series::new(
+                    "avg_disc_var",
+                    calculate_div_var(
+                        &df.column("l_discount_sum").unwrap().cast(&polars::datatypes::DataType::Float64).unwrap(),
+                        df.column("l_discount_sum_var").unwrap(),
+                        &df.column("l_orderkey_count").unwrap().cast(&polars::datatypes::DataType::Float64).unwrap(),
+                        df.column("l_orderkey_count_var").unwrap(),
+                        df.column("l_discount_sum_l_orderkey_count_cov").unwrap(),
+                        &avg_disc
+                    )
+                ),
+                Series::new("count_order_var", df.column("l_orderkey_count_var").unwrap()),
+            ];
+            DataFrame::new(columns)
+                .unwrap()
+                .sort(&["l_returnflag", "l_linestatus"], vec![false, false])
+                .unwrap()
+        })))
+        .build();
+
+    // Connect nodes with subscription
+    where_node.subscribe_to_node(&lineitem_csvreader_node, 0);
+    expression_node.subscribe_to_node(&where_node, 0);
+    groupby_node.subscribe_to_node(&expression_node, 0);
+    select_node.subscribe_to_node(&groupby_node, 0);
+
+    // Output reader subscribe to output node.
+    output_reader.subscribe_to_node(&select_node, 0);
+
+    // Add all the nodes to the service
+    let mut service = ExecutionService::<polars::prelude::DataFrame>::create();
+    service.add(select_node);
+    service.add(groupby_node);
+    service.add(expression_node);
+    service.add(where_node);
+    service.add(lineitem_csvreader_node);
+    service
+}

--- a/deepola/wake/examples/tpch_polars/q30.rs
+++ b/deepola/wake/examples/tpch_polars/q30.rs
@@ -1,0 +1,97 @@
+use std::rc::Rc;
+
+use crate::prelude::*;
+use wake::processor::MessageFractionProcessor;
+
+
+/// This node implements the following types of SQL query
+// SELECT sum(t.x) as x
+// FROM (
+//   SELECT max(t.x) as x
+//   FROM (
+//     SELECT sum(t.x) as x
+//     FROM (
+//       SELECT max(t.x) as x
+//       FROM   numbertable as t
+//       GROUP BY c, ci, cii
+//     ) AS t
+//     GROUP BY c, ci
+//   ) AS t
+//   GROUP BY c
+// ) AS t
+
+fn make_scaler(aggregate_column: &str, aggregate_op: &str) -> Rc<dyn MessageFractionProcessor<DataFrame>> {
+    match aggregate_op {
+        "sum" => {
+            AggregateScaler::new_growing()
+                .remove_count_column()  // Remove added group count column
+                .scale_sum(aggregate_column.into())
+                .into_rc()
+        },
+        "max" => {
+            AggregateScaler::new_growing()
+                .remove_count_column()  // Remove added group count column
+                .into_rc()
+        },
+        _ => panic!("Unsupported aggregate operator"),
+    }
+}
+
+pub fn query(
+    tableinput: HashMap<String, TableInput>,
+    output_reader: &mut NodeReader<polars::prelude::DataFrame>,
+    query_depth: usize
+) -> ExecutionService<polars::prelude::DataFrame> {
+    let agg_cycle = vec!["sum", "max"];  // configurable?
+
+    // Table Name => Columns to Read.
+    let gb_columns: Vec<String> = (1 .. query_depth + 1)
+        .map(|idx| "c".to_string() + &"i".repeat(idx))
+        .collect();
+    let gb_columns_borrow: Vec<&str> = gb_columns.iter().map(|s| &s[..]).collect();
+    let numbertable_columns = HashMap::from([
+        ("numbertable".into(), [gb_columns_borrow, vec!["x"]].concat()),
+    ]);
+
+    // CSV Reader Nodes.
+    let numbertable_csvreader_node = build_reader_node("numbertable".into(), &tableinput, &numbertable_columns);
+
+    // GROUP BY AGGREGATE Nodes
+    let mut groupby_nodes = Vec::new();
+    let mut value_column = "x".to_string();
+    for depth in (0 .. query_depth + 1).rev() {
+        let mut agg_accumulator = AggAccumulator::new();
+        let aggregate_op = agg_cycle[depth % agg_cycle.len()];
+        let aggregate_column = format!("{}_{}", value_column, aggregate_op);
+        agg_accumulator
+            .set_group_key(gb_columns[..depth].to_vec())
+            .set_aggregates(vec![(value_column.clone(), vec![aggregate_op.to_string()])])
+            .set_add_count_column(true)
+            .set_scaler(make_scaler(&aggregate_column, &aggregate_op));
+        let groupby_node = AccumulatorNode::<DataFrame, AggAccumulator>::new()
+            .accumulator(agg_accumulator)
+            .build();
+        groupby_nodes.push(groupby_node);
+        value_column = aggregate_column;
+    }
+
+    // Connect nodes with subscription
+    groupby_nodes.first().unwrap().subscribe_to_node(&numbertable_csvreader_node, 0);
+    for groupby_node_pair in groupby_nodes.windows(2) {
+        assert_eq!(groupby_node_pair.len(), 2);
+        let groupby_node_1 = &groupby_node_pair[0];
+        let groupby_node_2 = &groupby_node_pair[1];
+        groupby_node_2.subscribe_to_node(&groupby_node_1, 0);
+    }
+
+    // Output reader subscribe to output node.
+    output_reader.subscribe_to_node(&groupby_nodes.last().unwrap(), 0);
+
+    // Add all the nodes to the service
+    let mut service = ExecutionService::<polars::prelude::DataFrame>::create();
+    service.add(numbertable_csvreader_node);
+    for groupby_node in groupby_nodes {
+        service.add(groupby_node);
+    }
+    service
+}

--- a/deepola/wake/examples/tpch_polars/q5c.rs
+++ b/deepola/wake/examples/tpch_polars/q5c.rs
@@ -1,0 +1,184 @@
+use crate::prelude::*;
+
+/// This node implements the following SQL query
+// select
+//  n_name,
+//  sum(l_extendedprice * (1 - l_discount)) as revenue
+// from
+//  customer,
+//  orders,
+//  lineitem,
+//  supplier,
+//  nation,
+//  region
+// where
+//  c_custkey = o_custkey
+//  and l_orderkey = o_orderkey
+//  and l_suppkey = s_suppkey
+//  and c_nationkey = s_nationkey
+//  and s_nationkey = n_nationkey
+//  and n_regionkey = r_regionkey
+//  and r_name = 'ASIA'
+//  and o_orderdate >= date '1994-01-01'
+//  and o_orderdate < date '1994-01-01' + interval '1' year
+// group by
+//  n_name
+// order by
+//  revenue desc;
+
+pub fn query(
+    tableinput: HashMap<String, TableInput>,
+    output_reader: &mut NodeReader<polars::prelude::DataFrame>,
+) -> ExecutionService<polars::prelude::DataFrame> {
+    // Table Name => Columns to Read.
+    let table_columns = HashMap::from([
+        ("customer".into(), vec!["c_custkey", "c_nationkey"]),
+        (
+            "orders".into(),
+            vec!["o_orderkey", "o_custkey", "o_orderdate"],
+        ),
+        (
+            "lineitem".into(),
+            vec!["l_orderkey", "l_suppkey", "l_extendedprice", "l_discount"],
+        ),
+        ("supplier".into(), vec!["s_suppkey", "s_nationkey"]),
+        (
+            "nation".into(),
+            vec!["n_regionkey", "n_nationkey", "n_name"],
+        ),
+        ("region".into(), vec!["r_regionkey", "r_name"]),
+    ]);
+
+    // CSV Reader Nodes.
+    let customer_csvreader_node = build_reader_node("customer".into(), &tableinput, &table_columns);
+    let orders_csvreader_node = build_reader_node("orders".into(), &tableinput, &table_columns);
+    let lineitem_csvreader_node = build_reader_node("lineitem".into(), &tableinput, &table_columns);
+    let supplier_csvreader_node = build_reader_node("supplier".into(), &tableinput, &table_columns);
+    let nation_csvreader_node = build_reader_node("nation".into(), &tableinput, &table_columns);
+    let region_csvreader_node = build_reader_node("region".into(), &tableinput, &table_columns);
+
+    // WHERE Nodes
+    let orders_where_node = AppenderNode::<DataFrame, MapAppender>::new()
+        .appender(MapAppender::new(Box::new(|df: &DataFrame| {
+            let var_date_1 = days_since_epoch(1994,1,1);
+            let var_date_2 = days_since_epoch(1995,1,1);
+            let o_orderdate = df.column("o_orderdate").unwrap();
+            let mask =
+                o_orderdate.gt_eq(var_date_1).unwrap() & o_orderdate.lt(var_date_2).unwrap();
+            df.filter(&mask).unwrap()
+        })))
+        .build();
+
+    let region_where_node = AppenderNode::<DataFrame, MapAppender>::new()
+        .appender(MapAppender::new(Box::new(|df: &DataFrame| {
+            let r_name = df.column("r_name").unwrap();
+            let mask = r_name.equal("ASIA").unwrap();
+            df.filter(&mask).unwrap()
+        })))
+        .build();
+
+    let nr_hash_join_node = HashJoinBuilder::new()
+        .left_on(vec!["n_regionkey".into()])
+        .right_on(vec!["r_regionkey".into()])
+        .build();
+
+    let sn_hash_join_node = HashJoinBuilder::new()
+        .left_on(vec!["s_nationkey".into()])
+        .right_on(vec!["n_nationkey".into()])
+        .build();
+
+    let ls_hash_join_node = HashJoinBuilder::new()
+        .left_on(vec!["l_suppkey".into()])
+        .right_on(vec!["s_suppkey".into()])
+        .build();
+
+    let oc_hash_join_node = HashJoinBuilder::new()
+        .left_on(vec!["o_custkey".into(), "s_nationkey".into()])
+        .right_on(vec!["c_custkey".into(), "c_nationkey".into()])
+        .build();
+
+    let mut merger = SortedDfMerger::new();
+    merger.set_left_on(vec!["l_orderkey".into()]);
+    merger.set_right_on(vec!["o_orderkey".into()]);
+    let lo_merge_join_node = MergerNode::<DataFrame, SortedDfMerger>::new()
+        .merger(merger)
+        .build();
+
+    let expression_node = AppenderNode::<DataFrame, MapAppender>::new()
+        .appender(MapAppender::new(Box::new(|df: &DataFrame| {
+            let extended_price = df.column("l_extendedprice").unwrap();
+            let discount = df.column("l_discount").unwrap();
+            let disc_price = Series::new(
+                "disc_price",
+                extended_price
+                    .cast(&polars::datatypes::DataType::Float64)
+                    .unwrap()
+                    * (discount * -1f64 + 1f64),
+            );
+            df.hstack(&[disc_price]).unwrap()
+        })))
+        .build();
+
+    // GROUP BY AGGREGATE Node
+    let mut agg_accumulator = AggAccumulator::new();
+    agg_accumulator
+        .set_group_key(vec!["n_name".into()])
+        .set_aggregates(vec![("disc_price".into(), vec!["sum".into()])])
+        .set_add_count_column(true)
+        .set_track_variance(true)
+        .set_scaler(AggregateScaler::new_growing()
+            .remove_count_column()  // Remove added group count column
+            .scale_sum_with_variance("disc_price_sum".into(), "disc_price_var".into())
+            .track_variance()
+            .into_rc()
+        );
+    let groupby_node = AccumulatorNode::<DataFrame, AggAccumulator>::new()
+        .accumulator(agg_accumulator)
+        .build();
+
+    let select_node = AppenderNode::<DataFrame, MapAppender>::new()
+        .appender(MapAppender::new(Box::new(|df: &DataFrame| {
+            df.sort(vec!["disc_price_sum"], vec![true]).unwrap()
+        })))
+        .build();
+
+    // Connect nodes with subscription
+    region_where_node.subscribe_to_node(&region_csvreader_node, 0);
+    orders_where_node.subscribe_to_node(&orders_csvreader_node, 0);
+    nr_hash_join_node.subscribe_to_node(&nation_csvreader_node, 0);
+    nr_hash_join_node.subscribe_to_node(&region_where_node, 1);
+    sn_hash_join_node.subscribe_to_node(&supplier_csvreader_node, 0);
+    sn_hash_join_node.subscribe_to_node(&nr_hash_join_node, 1);
+    ls_hash_join_node.subscribe_to_node(&lineitem_csvreader_node, 0);
+    ls_hash_join_node.subscribe_to_node(&sn_hash_join_node, 1);
+    lo_merge_join_node.subscribe_to_node(&ls_hash_join_node, 0);
+    lo_merge_join_node.subscribe_to_node(&orders_where_node, 1);
+    oc_hash_join_node.subscribe_to_node(&lo_merge_join_node, 0);
+    oc_hash_join_node.subscribe_to_node(&customer_csvreader_node, 1);
+    expression_node.subscribe_to_node(&oc_hash_join_node, 0);
+    groupby_node.subscribe_to_node(&expression_node, 0);
+    select_node.subscribe_to_node(&groupby_node, 0);
+
+    // Output reader subscribe to output node.
+    output_reader.subscribe_to_node(&select_node, 0);
+
+    // Add all the nodes to the service
+    let mut service = ExecutionService::<polars::prelude::DataFrame>::create();
+    service.add(orders_csvreader_node);
+    service.add(region_csvreader_node);
+    service.add(nation_csvreader_node);
+    service.add(lineitem_csvreader_node);
+    service.add(supplier_csvreader_node);
+    service.add(customer_csvreader_node);
+    service.add(region_where_node);
+    service.add(orders_where_node);
+    service.add(nr_hash_join_node);
+    service.add(sn_hash_join_node);
+    service.add(ls_hash_join_node);
+    service.add(oc_hash_join_node);
+    service.add(lo_merge_join_node);
+    service.add(expression_node);
+    service.add(groupby_node);
+    service.add(select_node);
+    service
+}

--- a/deepola/wake/examples/tpch_polars/q6c.rs
+++ b/deepola/wake/examples/tpch_polars/q6c.rs
@@ -1,0 +1,85 @@
+use crate::prelude::*;
+
+/// This node implements the following SQL query
+// select
+//  sum(l_extendedprice * l_discount) as revenue
+// from
+//  lineitem
+// where
+//  l_shipdate >= date '1994-01-01'
+//  and l_shipdate < date '1994-01-01' + interval '1' year
+//  and l_discount between .06 - 0.01 and .06 + 0.01
+//  and l_quantity < 24;
+
+pub fn query(
+    tableinput: HashMap<String, TableInput>,
+    output_reader: &mut NodeReader<polars::prelude::DataFrame>,
+) -> ExecutionService<polars::prelude::DataFrame> {
+    // Create a HashMap that stores table name and the columns in that query.
+    let table_columns = HashMap::from([(
+        "lineitem".into(),
+        vec!["l_quantity", "l_extendedprice", "l_discount", "l_shipdate"],
+    )]);
+
+    // CSVReaderNode would be created for this table.
+    let lineitem_csvreader_node = build_reader_node_permute_files("lineitem".into(), &tableinput, &table_columns);
+
+    // WHERE Node
+    let where_node = AppenderNode::<DataFrame, MapAppender>::new()
+        .appender(MapAppender::new(Box::new(|df: &DataFrame| {
+            let l_shipdate = df.column("l_shipdate").unwrap();
+            let l_discount = df.column("l_discount").unwrap();
+            let l_quantity = df.column("l_quantity").unwrap();
+            let var_date_1 = days_since_epoch(1994,1,1);
+            let var_date_2 = days_since_epoch(1995,1,1);
+            let mask = l_shipdate.gt_eq(var_date_1).unwrap()
+                & l_shipdate.lt(var_date_2).unwrap()
+                & l_discount.gt_eq(0.05).unwrap()
+                & l_discount.lt_eq(0.07).unwrap()
+                & l_quantity.lt(24).unwrap();
+            df.filter(&mask).unwrap()
+        })))
+        .build();
+
+    // EXPRESSION Node
+    let expression_node = AppenderNode::<DataFrame, MapAppender>::new()
+        .appender(MapAppender::new(Box::new(|df: &DataFrame| {
+            let extended_price = df.column("l_extendedprice").unwrap();
+            let discount = df.column("l_discount").unwrap();
+            let columns = vec![Series::new("disc_price", extended_price * discount)];
+            DataFrame::new(columns).unwrap()
+        })))
+        .build();
+
+    // GROUP BY Aggregate Node
+    let mut agg_accumulator = AggAccumulator::new();
+    agg_accumulator
+        .set_aggregates(vec![("disc_price".into(), vec!["sum".into()])])
+        .set_add_count_column(true)
+        .set_track_variance(true)
+        .set_scaler(AggregateScaler::new_growing()
+            .remove_count_column()  // Remove added group count column
+            .scale_sum_with_variance("disc_price_sum".into(), "disc_price_var".into())
+            .track_variance()
+            .into_rc()
+        );
+    let groupby_node = AccumulatorNode::<DataFrame, AggAccumulator>::new()
+        .accumulator(agg_accumulator)
+        .build();
+
+    // Connect nodes with subscription
+    where_node.subscribe_to_node(&lineitem_csvreader_node, 0);
+    expression_node.subscribe_to_node(&where_node, 0);
+    groupby_node.subscribe_to_node(&expression_node, 0);
+
+    // Output reader subscribe to output node.
+    output_reader.subscribe_to_node(&groupby_node, 0);
+
+    // Add all the nodes to the service
+    let mut service = ExecutionService::<polars::prelude::DataFrame>::create();
+    service.add(groupby_node);
+    service.add(expression_node);
+    service.add(where_node);
+    service.add(lineitem_csvreader_node);
+    service
+}

--- a/deepola/wake/examples/tpch_polars/q8c.rs
+++ b/deepola/wake/examples/tpch_polars/q8c.rs
@@ -1,0 +1,293 @@
+use crate::prelude::*;
+
+/// This node implements the following SQL query
+// select
+//  o_year,
+//  sum(case
+//      when nation = 'BRAZIL' then volume
+//      else 0
+//  end) / sum(volume) as mkt_share
+// from
+//  (
+//      select
+//          extract(year from o_orderdate) as o_year,
+//          l_extendedprice * (1 - l_discount) as volume,
+//          n2.n_name as nation
+//      from
+//          part,
+//          supplier,
+//          lineitem,
+//          orders,
+//          customer,
+//          nation n1,
+//          nation n2,
+//          region
+//      where
+//          p_partkey = l_partkey
+//          and s_suppkey = l_suppkey
+//          and l_orderkey = o_orderkey
+//          and o_custkey = c_custkey
+//          and c_nationkey = n1.n_nationkey
+//          and n1.n_regionkey = r_regionkey
+//          and r_name = 'AMERICA'
+//          and s_nationkey = n2.n_nationkey
+//          and o_orderdate between date '1995-01-01' and date '1996-12-31'
+//          and p_type = 'ECONOMY ANODIZED STEEL'
+//  ) as all_nations
+// group by
+//  o_year
+// order by
+//  o_year;
+
+pub fn query(
+    tableinput: HashMap<String, TableInput>,
+    output_reader: &mut NodeReader<polars::prelude::DataFrame>,
+) -> ExecutionService<polars::prelude::DataFrame> {
+    // Table Name => Columns to Read.
+    let table_columns = HashMap::from([
+        (
+            "nation".into(),
+            vec!["n_nationkey", "n_regionkey", "n_name"],
+        ),
+        ("region".into(), vec!["r_regionkey", "r_name"]),
+        ("customer".into(), vec!["c_custkey", "c_nationkey"]),
+        ("part".into(), vec!["p_partkey", "p_type"]),
+        ("supplier".into(), vec!["s_suppkey", "s_nationkey"]),
+        (
+            "orders".into(),
+            vec!["o_orderkey", "o_custkey", "o_orderdate"],
+        ),
+        (
+            "lineitem".into(),
+            vec![
+                "l_orderkey",
+                "l_suppkey",
+                "l_partkey",
+                "l_extendedprice",
+                "l_discount",
+            ],
+        ),
+    ]);
+
+    // CSV Reader Nodes.
+    let nation_csvreader_node = build_reader_node("nation".into(), &tableinput, &table_columns);
+    let region_csvreader_node = build_reader_node("region".into(), &tableinput, &table_columns);
+    let customer_csvreader_node = build_reader_node("customer".into(), &tableinput, &table_columns);
+    let part_csvreader_node = build_reader_node("part".into(), &tableinput, &table_columns);
+    let supplier_csvreader_node = build_reader_node("supplier".into(), &tableinput, &table_columns);
+    let orders_csvreader_node = build_reader_node("orders".into(), &tableinput, &table_columns);
+    let lineitem_csvreader_node = build_reader_node("lineitem".into(), &tableinput, &table_columns);
+
+    // WHERE Nodes
+    let region_where_node = AppenderNode::<DataFrame, MapAppender>::new()
+        .appender(MapAppender::new(Box::new(|df: &DataFrame| {
+            let r_name = df.column("r_name").unwrap();
+            let mask = r_name.equal("AMERICA").unwrap();
+            df.filter(&mask).unwrap()
+        })))
+        .build();
+
+    let part_where_node = AppenderNode::<DataFrame, MapAppender>::new()
+        .appender(MapAppender::new(Box::new(|df: &DataFrame| {
+            let p_type = df.column("p_type").unwrap();
+            let mask = p_type.equal("ECONOMY ANODIZED STEEL").unwrap();
+            df.filter(&mask).unwrap()
+        })))
+        .build();
+
+    let orders_where_node = AppenderNode::<DataFrame, MapAppender>::new()
+        .appender(MapAppender::new(Box::new(|df: &DataFrame| {
+            let var_date_1 = days_since_epoch(1995,1,1);
+            let var_date_2 = days_since_epoch(1996,12,31);
+            let o_orderdate = df.column("o_orderdate").unwrap();
+            let mask =
+                o_orderdate.gt_eq(var_date_1).unwrap() & o_orderdate.lt_eq(var_date_2).unwrap();
+            df.filter(&mask).unwrap()
+        })))
+        .build();
+
+    // After this rename, n_name to supp_nation
+    let nr_hash_join_node = HashJoinBuilder::new()
+        .left_on(vec!["n_regionkey".into()])
+        .right_on(vec!["r_regionkey".into()])
+        .build();
+
+    let cn_hash_join_node = HashJoinBuilder::new()
+        .left_on(vec!["c_nationkey".into()])
+        .right_on(vec!["n_nationkey".into()])
+        .build();
+
+    let oc_hash_join_node = HashJoinBuilder::new()
+        .left_on(vec!["o_custkey".into()])
+        .right_on(vec!["c_custkey".into()])
+        .build();
+
+    let sn_hash_join_node = HashJoinBuilder::new()
+        .left_on(vec!["s_nationkey".into()])
+        .right_on(vec!["n_nationkey".into()])
+        .build();
+    let sn_expression_node = AppenderNode::<DataFrame, MapAppender>::new()
+        .appender(MapAppender::new(Box::new(|df: &DataFrame| {
+            let cols = vec![
+                Series::new("s_suppkey", df.column("s_suppkey").unwrap()),
+                Series::new("nation", df.column("n_name").unwrap()),
+            ];
+            DataFrame::new(cols).unwrap()
+        })))
+        .build();
+
+    let ls_hash_join_node = HashJoinBuilder::new()
+        .left_on(vec!["l_suppkey".into()])
+        .right_on(vec!["s_suppkey".into()])
+        .build();
+
+    let lp_hash_join_node = HashJoinBuilder::new()
+        .left_on(vec!["l_partkey".into()])
+        .right_on(vec!["p_partkey".into()])
+        .build();
+
+    let mut merger = SortedDfMerger::new();
+    merger.set_left_on(vec!["l_orderkey".into()]);
+    merger.set_right_on(vec!["o_orderkey".into()]);
+    let lo_merge_join_node = MergerNode::<DataFrame, SortedDfMerger>::new()
+        .merger(merger)
+        .build();
+
+    // Expression Node.
+    let expression_node = AppenderNode::<DataFrame, MapAppender>::new()
+        .appender(MapAppender::new(Box::new(|df: &DataFrame| {
+            let nation = df.column("nation").unwrap();
+            let extended_price = df.column("l_extendedprice").unwrap();
+            let discount = df.column("l_discount").unwrap();
+            let volume = Series::new(
+                "volume",
+                extended_price
+                    .cast(&polars::datatypes::DataType::Float64)
+                    .unwrap()
+                    * (discount * -1f64 + 1f64),
+            );
+            let mask = nation
+                .equal("BRAZIL")
+                .unwrap()
+                .cast(&polars::datatypes::DataType::UInt32)
+                .unwrap();
+            let masked_volume = Series::new("masked_volume", volume.clone() * mask);
+            let o_orderdate = df.column("o_orderdate").unwrap();
+            let o_year = Series::new("o_year", o_orderdate.year().unwrap().into_series());
+            DataFrame::new(vec![o_year, volume, masked_volume]).unwrap()
+        })))
+        .build();
+
+    // GROUP BY Node.
+    let mut agg_accumulator = AggAccumulator::new();
+    agg_accumulator
+        .set_group_key(vec!["o_year".into()])
+        .set_aggregates(vec![
+            ("volume".into(), vec!["sum".into()]),
+            ("masked_volume".into(), vec!["sum".into()]),
+        ])
+        .set_add_count_column(true)
+        .set_track_variance(true)
+        .set_scaler(AggregateScaler::new_growing()
+            .remove_count_column()  // Remove added group count column
+            .scale_sum_with_variance("volume_sum".into(), "volume_var".into())
+            .scale_sum_with_variance("masked_volume_sum".into(), "masked_volume_var".into())
+            .track_sum_sum_covariance("volume_sum".into(), "masked_volume_sum".into())
+            .track_variance()
+            .into_rc()
+        );
+    let groupby_node = AccumulatorNode::<DataFrame, AggAccumulator>::new()
+        .accumulator(agg_accumulator)
+        .build();
+
+    let select_node = AppenderNode::<DataFrame, MapAppender>::new()
+        .appender(MapAppender::new(Box::new(|df: &DataFrame| {
+            // Select row and divide to get mkt_share
+            let o_year = df.column("o_year").unwrap().clone();
+            let masked_volume_sum = df.column("masked_volume_sum").unwrap();
+            let masked_volume_sum_var = df.column("masked_volume_sum_var").unwrap();
+            let volume_sum = df.column("volume_sum").unwrap();
+            let volume_sum_var = df.column("volume_sum_var").unwrap();
+            let volume_sum_masked_volume_sum_cov = df.column("volume_sum_masked_volume_sum_cov").unwrap();
+            let mkt_share = Series::new("mkt_share", masked_volume_sum / volume_sum);
+            // TODO: Automate this differentiation
+            let mkt_share_var = Series::new(
+                "mkt_share_var",
+                calculate_div_var(
+                    masked_volume_sum,
+                    masked_volume_sum_var,
+                    volume_sum,
+                    volume_sum_var,
+                    volume_sum_masked_volume_sum_cov,
+                    &mkt_share,
+                )
+            );
+            DataFrame::new(vec![o_year, mkt_share, mkt_share_var])
+                .unwrap()
+                .sort(vec!["o_year"], vec![false])
+                .unwrap()
+        })))
+        .build();
+
+    // Connect nodes with subscription
+    region_where_node.subscribe_to_node(&region_csvreader_node, 0);
+    orders_where_node.subscribe_to_node(&orders_csvreader_node, 0);
+    part_where_node.subscribe_to_node(&part_csvreader_node, 0);
+
+    nr_hash_join_node.subscribe_to_node(&nation_csvreader_node, 0);
+    nr_hash_join_node.subscribe_to_node(&region_where_node, 1);
+
+    cn_hash_join_node.subscribe_to_node(&customer_csvreader_node, 0);
+    cn_hash_join_node.subscribe_to_node(&nr_hash_join_node, 1);
+
+    oc_hash_join_node.subscribe_to_node(&orders_where_node, 0);
+    oc_hash_join_node.subscribe_to_node(&cn_hash_join_node, 1);
+
+    sn_hash_join_node.subscribe_to_node(&supplier_csvreader_node, 0);
+    sn_hash_join_node.subscribe_to_node(&nation_csvreader_node, 1);
+
+    sn_expression_node.subscribe_to_node(&sn_hash_join_node, 0);
+
+    ls_hash_join_node.subscribe_to_node(&lineitem_csvreader_node, 0);
+    ls_hash_join_node.subscribe_to_node(&sn_expression_node, 1);
+
+    lp_hash_join_node.subscribe_to_node(&ls_hash_join_node, 0);
+    lp_hash_join_node.subscribe_to_node(&part_where_node, 1);
+
+    lo_merge_join_node.subscribe_to_node(&lp_hash_join_node, 0);
+    lo_merge_join_node.subscribe_to_node(&oc_hash_join_node, 1);
+
+    expression_node.subscribe_to_node(&lo_merge_join_node, 0);
+
+    groupby_node.subscribe_to_node(&expression_node, 0);
+
+    select_node.subscribe_to_node(&groupby_node, 0);
+
+    // Output reader subscribe to output node.
+    output_reader.subscribe_to_node(&select_node, 0);
+
+    // Add all the nodes to the service
+    let mut service = ExecutionService::<polars::prelude::DataFrame>::create();
+    service.add(nation_csvreader_node);
+    service.add(lineitem_csvreader_node);
+    service.add(orders_csvreader_node);
+    service.add(customer_csvreader_node);
+    service.add(supplier_csvreader_node);
+    service.add(part_csvreader_node);
+    service.add(region_csvreader_node);
+    service.add(region_where_node);
+    service.add(orders_where_node);
+    service.add(part_where_node);
+    service.add(nr_hash_join_node);
+    service.add(cn_hash_join_node);
+    service.add(oc_hash_join_node);
+    service.add(sn_hash_join_node);
+    service.add(sn_expression_node);
+    service.add(ls_hash_join_node);
+    service.add(lp_hash_join_node);
+    service.add(lo_merge_join_node);
+    service.add(expression_node);
+    service.add(groupby_node);
+    service.add(select_node);
+    service
+}

--- a/deepola/wake/examples/tpch_polars/utils.rs
+++ b/deepola/wake/examples/tpch_polars/utils.rs
@@ -42,16 +42,20 @@ pub fn total_number_of_records(table: &str, scale: usize) -> usize {
         "supplier" => 10_000 * scale,
         "nation" => 25,
         "region" => 5,
+        "numbertable" => 1_000_000 * scale,
         _ => 0,
     }
 }
 
-pub fn load_tables(directory: &str, scale: usize) -> HashMap<String, TableInput> {
+pub fn load_tables(directory: &str, scale: usize, use_numbertable: bool) -> HashMap<String, TableInput> {
     log::warn!("Specified Input Directory: {}", directory);
 
-    let tpch_tables = vec![
+    let mut tpch_tables = vec![
         "lineitem", "orders", "customer", "part", "partsupp", "region", "nation", "supplier",
     ];
+    if use_numbertable {
+        tpch_tables.push("numbertable")
+    }
     let mut table_input = HashMap::new();
     for tpch_table in tpch_tables {
         let mut input_files = vec![];
@@ -352,6 +356,19 @@ pub fn tpch_schema(table: &str) -> std::result::Result<wake::data::Schema, Box<d
             Column::from_field("ps_availqty".to_string(), wake::data::DataType::Integer),
             Column::from_field("ps_supplycost".to_string(), wake::data::DataType::Float),
             Column::from_field("ps_comment".to_string(), wake::data::DataType::Text),
+        ],
+        "numbertable" => vec![
+            Column::from_field("ci".to_string(), wake::data::DataType::Integer),
+            Column::from_field("cii".to_string(), wake::data::DataType::Integer),
+            Column::from_field("ciii".to_string(), wake::data::DataType::Integer),
+            Column::from_field("ciiii".to_string(), wake::data::DataType::Integer),
+            Column::from_field("ciiiii".to_string(), wake::data::DataType::Integer),
+            Column::from_field("ciiiiii".to_string(), wake::data::DataType::Integer),
+            Column::from_field("ciiiiiii".to_string(), wake::data::DataType::Integer),
+            Column::from_field("ciiiiiiii".to_string(), wake::data::DataType::Integer),
+            Column::from_field("ciiiiiiiii".to_string(), wake::data::DataType::Integer),
+            Column::from_field("ciiiiiiiiii".to_string(), wake::data::DataType::Integer),
+            Column::from_field("x".to_string(), wake::data::DataType::Integer),
         ],
         _ => vec![],
     };

--- a/deepola/wake/src/inference/count.rs
+++ b/deepola/wake/src/inference/count.rs
@@ -1,7 +1,9 @@
 use std::cell::RefCell;
 
 use crate::forecast::cell::CellConsumer;
+use crate::forecast::cell::CellEstimator;
 use crate::forecast::cell::LeastSquareAffineEstimator;
+use crate::forecast::cell::LeastSquareVariance;
 use crate::forecast::TimeValue;
 
 
@@ -11,7 +13,10 @@ pub struct PowerCardinalityEstimator {
 
     /// Estimate power to the mean count
     power_estimator: RefCell<LeastSquareAffineEstimator>,
-}
+
+    /// To compute variance of slope through residual sum of squared (RSS)
+    ols_var: RefCell<Option<LeastSquareVariance>>,
+ }
 
 
 impl PowerCardinalityEstimator {
@@ -19,6 +24,7 @@ impl PowerCardinalityEstimator {
         PowerCardinalityEstimator {
             power: RefCell::new(0.0),
             power_estimator: RefCell::new(LeastSquareAffineEstimator::default()),
+            ols_var: RefCell::new(None),
         }
     }
 
@@ -27,6 +33,7 @@ impl PowerCardinalityEstimator {
         PowerCardinalityEstimator {
             power: RefCell::new(power),
             power_estimator: RefCell::new(LeastSquareAffineEstimator::default()),
+            ols_var: RefCell::new(None),
         }
     }
 
@@ -34,7 +41,12 @@ impl PowerCardinalityEstimator {
         PowerCardinalityEstimator {
             power: RefCell::new(1.0),
             power_estimator: RefCell::new(LeastSquareAffineEstimator::default()),
+            ols_var: RefCell::new(None),
         }
+    }
+
+    pub fn track_variance(&mut self) {
+        *self.ols_var.borrow_mut() = Some(LeastSquareVariance::default());
     }
 
     pub fn estimate(&self, count: f64, fraction: f64) -> f64 {
@@ -46,17 +58,28 @@ impl PowerCardinalityEstimator {
         }
     }
 
+    pub fn estimate_with_variance(&self, count: f64, fraction: f64) -> (f64, f64) {
+        let slope_variance = self.ols_var.borrow().as_ref()
+            .expect("Need to enable variance tracking beforehand")
+            .slope_variance();
+        let estimate_count = self.estimate(count, fraction);
+        let count_variance = slope_variance * estimate_count.powi(2) * (1.0 / fraction).ln();
+        (estimate_count, count_variance)
+    }
+
     pub fn update_power(&self, total_count: f64, group_count: f64, fraction: f64) {
-        let new_power = {
-            let mut power_estimator = self.power_estimator.borrow_mut();
-            let count = total_count / group_count;  // Average group cardinality.
-            let log_count = count.ln();
-            let log_fraction = fraction.ln();
-            power_estimator.consume(&TimeValue { t: log_fraction, v: log_count });
-            // log::error!("count_mean= {:.2}, fraction= {:.2}: slope= {:.2}, intercept= {:.2}", count, fraction, power_estimator.slope(), power_estimator.intercept());
-            power_estimator.slope()
-        };
-        self.set_power(new_power)
+        let mut power_estimator = self.power_estimator.borrow_mut();
+        let count = total_count / group_count;  // Average group cardinality.
+        let log_count = count.ln();
+        let log_fraction = fraction.ln();
+        power_estimator.consume(&TimeValue { t: log_fraction, v: log_count });
+        // log::error!("count_mean= {:.2}, fraction= {:.2}: slope= {:.2}, intercept= {:.2}", count, fraction, power_estimator.slope(), power_estimator.intercept());
+        self.set_power(power_estimator.slope());
+
+        if let Some(ols_var_borrow) = self.ols_var.borrow_mut().as_mut() {
+            let forecast = power_estimator.produce();
+            ols_var_borrow.consume(forecast.as_ref(), log_fraction, log_count)
+        }
     }
 
     fn set_power(&self, power: f64) {

--- a/deepola/wake/src/inference/count_distinct.rs
+++ b/deepola/wake/src/inference/count_distinct.rs
@@ -22,12 +22,12 @@ type RealFn = Box<dyn Fn(f64) -> f64>;
 fn newton_raphson(f: RealFn, dfdx: RealFn, mut x0: f64, max_iter: usize, tol: f64) -> f64 {
     for _ in 0..max_iter {
         let diff = f(x0) / dfdx(x0);
-        x0 = x0 - diff;
+        x0 -= diff;
         if diff.abs() < tol {
             break;
         }
     }
-    return x0
+    x0
 }
 
 // fn generate_mm0_fn(current_count: f64, sample_size: f64) -> (RealFn, RealFn) {

--- a/deepola/wake/src/inference/mod.rs
+++ b/deepola/wake/src/inference/mod.rs
@@ -5,3 +5,4 @@ mod scaler;
 pub use count_distinct::HorvitzThompsonCountDistinct;
 pub use count_distinct::MM0CountDistinct;
 pub use scaler::AggregateScaler;
+pub use scaler::calculate_div_var;

--- a/deepola/wake/src/inference/scaler.rs
+++ b/deepola/wake/src/inference/scaler.rs
@@ -1,5 +1,7 @@
+use itertools::izip;
 use polars::datatypes::DataType;
 use polars::frame::DataFrame;
+use polars::prelude::NamedFrom;
 use polars::series::Series;
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -33,6 +35,12 @@ pub struct AggregateScaler {
 
     /// Whether to remove group count column after scaling
     remove_count_col: bool,
+
+    /// Whether to propagate variance
+    track_variance: bool,
+    track_variance_sum_col: Vec<(String, String)>,
+    track_covariance_sum_sum_col: Vec<(String, String)>,
+    track_variance_count_col: Vec<String>,
 }
 
 unsafe impl Send for AggregateScaler {}
@@ -45,6 +53,10 @@ impl AggregateScaler {
             count_estimator: RefCell::new(count_estimator),
             count_col: DEFAULT_GROUP_COLUMN_COUNT.into(),
             remove_count_col: false,
+            track_variance: false,
+            track_variance_sum_col: Vec::new(),
+            track_covariance_sum_sum_col: Vec::new(),
+            track_variance_count_col: Vec::new(),
         }
     }
 
@@ -75,8 +87,31 @@ impl AggregateScaler {
         self
     }
 
+    pub fn scale_sum_with_variance(mut self, column: String, var_column: String) -> Self {
+        self.aggregates.push((column.clone(), AggregationType::Sum));
+        self.track_variance_sum_col.push((column, var_column));
+        self
+    }
+
+    pub fn track_sum_sum_covariance(mut self, column_1: String, column_2: String) -> Self {
+        self.track_covariance_sum_sum_col.push((column_1, column_2));
+        self
+    }
+
     pub fn scale_count(mut self, column: String) -> Self {
         self.aggregates.push((column, AggregationType::Count));
+        self
+    }
+
+    pub fn scale_count_with_variance(mut self, column: String) -> Self {
+        self.aggregates.push((column.clone(), AggregationType::Count));
+        self.track_variance_count_col.push(column);
+        self
+    }
+
+    pub fn track_variance(mut self) -> Self {
+        self.count_estimator.borrow_mut().track_variance();
+        self.track_variance = true;
         self
     }
 
@@ -90,7 +125,106 @@ impl AggregateScaler {
 }
 
 /// Application methods
-impl MessageFractionProcessor<DataFrame> for AggregateScaler {
+impl AggregateScaler {
+    fn process_with_variance(&self, df: &DataFrame, fraction: f64) -> DataFrame {
+        assert!(self.track_variance);
+        let mut out_df = df.clone();
+
+        // Update scaling power.
+        let x0 = df.column(&self.count_col)
+            .unwrap_or_else(|_| panic!("Count column {} not found", self.count_col))
+            .clone();
+        self.count_estimator.borrow_mut()
+            .update_power(x0.sum::<f64>().unwrap(), df.height() as f64, fraction);
+
+        // Estimate final counts
+        let (xhat, xhat_var): (Vec<f64>, Vec<f64>) = x0
+            .u32()
+            .unwrap_or_else(|_| panic!("Count column {} is not u32", self.count_col))
+            .into_iter()
+            .map(|opt_count| opt_count.map_or((0.0, 0.0), |count| {
+                self.count_estimator.borrow().estimate_with_variance(count.into(), fraction)
+            }))
+            .unzip();
+        let xhat: Series = xhat.iter().collect();
+        let xhat_var: Series = xhat_var.iter().collect();
+
+        // Scale aggregate accordingly.
+        for (aggregate_col, aggregate_type) in &self.aggregates {
+            match aggregate_type {
+                AggregationType::Sum => out_df.apply(aggregate_col, |aggregate_val| {
+                    log::trace!("{:?} ---> {:?}", &aggregate_val, &(aggregate_val / &x0) * &xhat);
+                    &(&aggregate_val.cast(&DataType::Float64).unwrap() / &x0) * &xhat
+                }).unwrap_or_else(|_| panic!("Failed to scale count at {}", aggregate_col)),
+                AggregationType::Count => out_df.apply(aggregate_col, |aggregate_val| {
+                    log::trace!("{:?} ---> {:?}", &aggregate_val, &xhat);
+                    xhat.clone()
+                }).unwrap_or_else(|_| panic!("Failed to scale count at {}", aggregate_col)),
+            };
+        }
+
+        // Propagate sum variance
+        for (sum_col, sample_var_col) in &self.track_variance_sum_col {
+            let sum = df.column(sum_col).unwrap();
+            let sample_var = df.column(sample_var_col).unwrap();
+            let sum_var: Vec<f64> = izip!(
+                    x0.u32().unwrap(),
+                    xhat.f64().unwrap(),
+                    xhat_var.f64().unwrap(),
+                    sum.cast(&DataType::Float64).unwrap().f64().unwrap(),
+                    sample_var.cast(&DataType::Float64).unwrap().f64().unwrap(),
+                ).map(|(x0, xhat, xhat_var, sum, sample_var)| {
+                    let x0: f64 = x0.unwrap().into();
+                    let xhat: f64 = xhat.unwrap();
+                    let xhat_var: f64 = xhat_var.unwrap();
+                    let sum: f64 = sum.unwrap();
+                    let sample_var: f64 = sample_var.unwrap();
+                    let mean_var = sample_var / x0;
+                    let sum_var = mean_var * xhat.powi(2) + xhat_var * (sum / x0).powi(2);
+                    // println!("x0= {:.0}, xhat= {:.0}, xhat_var= {:.0}, sum= {:.0}, sample_var= {:.0}, mean_var= {:.0}, sum_var= {:.0}", x0, xhat, xhat_var, sum, sample_var, mean_var, sum_var);
+                    sum_var
+                }).collect();
+            out_df.with_column(Series::new(&format!("{}_var", sum_col), sum_var))
+                .unwrap_or_else(|_| panic!("Failed to replace variance for sum {}", sum_col));
+        }
+
+        // Propagate sum-sum covariance
+        for (sum_col_1, sum_col_2) in &self.track_covariance_sum_sum_col {
+            let sum_1 = df.column(sum_col_1).unwrap();
+            let sum_2 = df.column(sum_col_2).unwrap();
+            let sum_sum_cov: Vec<f64> = izip!(
+                    x0.u32().unwrap(),
+                    xhat_var.f64().unwrap(),
+                    sum_1.cast(&DataType::Float64).unwrap().f64().unwrap(),
+                    sum_2.cast(&DataType::Float64).unwrap().f64().unwrap(),
+                ).map(|(x0, xhat_var, sum_1, sum_2)| {
+                    let x0: f64 = x0.unwrap().into();
+                    let xhat_var: f64 = xhat_var.unwrap();
+                    let sum_1: f64 = sum_1.unwrap();
+                    let sum_2: f64 = sum_2.unwrap();
+                    xhat_var * (sum_1 / x0) * (sum_2 / x0)
+                }).collect();
+            out_df.with_column(Series::new(&format!("{}_{}_cov", sum_col_1, sum_col_2), sum_sum_cov))
+                .unwrap_or_else(|_| panic!("Failed to replace covariance for sum-sum {}-{}", sum_col_1, sum_col_2));
+        }
+
+        // Propagate count variance
+        for count_col in &self.track_variance_count_col {
+            out_df.with_column(Series::new(&format!("{}_var", count_col), xhat_var.clone()))
+                .unwrap_or_else(|_| panic!("Failed to replace variance for count {}", count_col));
+        }
+
+        // Remove sample variance columns
+        for (_, sample_var_col) in &self.track_variance_sum_col {
+            let _ = out_df.drop_in_place(sample_var_col).unwrap();
+        }
+
+        if self.remove_count_col {
+            let _ = out_df.drop_in_place(&self.count_col).unwrap();
+        }
+        out_df
+    }
+
     fn process(&self, df: &DataFrame, fraction: f64) -> DataFrame {
         let mut df = df.clone();
 
@@ -131,6 +265,16 @@ impl MessageFractionProcessor<DataFrame> for AggregateScaler {
     }
 }
 
+impl MessageFractionProcessor<DataFrame> for AggregateScaler {
+    fn process(&self, df: &DataFrame, fraction: f64) -> DataFrame {
+        if self.track_variance {
+            self.process_with_variance(df, fraction)
+        } else {
+            self.process(df, fraction)
+        }
+    }
+}
+
 
 impl StreamProcessor<DataFrame> for AggregateScaler {
     fn process_stream(
@@ -140,4 +284,30 @@ impl StreamProcessor<DataFrame> for AggregateScaler {
     ) {
         self.process_stream_inner(input_stream, output_stream)
     }
+}
+
+pub fn calculate_div_var(
+    a: &Series, 
+    a_var: &Series, 
+    b: &Series, 
+    b_var: &Series, 
+    ab_cov: &Series, 
+    div: &Series,
+) -> Vec<f64> {
+    izip!(
+        a.f64().unwrap(),
+        a_var.f64().unwrap(),
+        b.f64().unwrap(),
+        b_var.f64().unwrap(),
+        ab_cov.f64().unwrap(),
+        div.f64().unwrap()
+    ).map(|(a, a_var, b, b_var, ab_cov, div)| {
+        let a: f64 = a.unwrap();
+        let a_var: f64 = a_var.unwrap();
+        let b: f64 = b.unwrap();
+        let b_var: f64 = b_var.unwrap();
+        let div: f64 = div.unwrap();
+        let ab_cov: f64 = ab_cov.unwrap();
+        div.powi(2) * (a_var / a.powi(2) + b_var / b.powi(2) - 2.0 * ab_cov / (a * b))
+    }).collect::<Vec<f64>>()
 }

--- a/deepola/wake/src/utils.rs
+++ b/deepola/wake/src/utils.rs
@@ -1,15 +1,15 @@
 use std::{thread::{ThreadId, current}, time::{UNIX_EPOCH, SystemTime}};
 
 pub fn log_node_mapping(node_id: &str, thread_id: ThreadId) {
-    log::warn!("[logging] (type,node-thread-map) (node,{node_id}) (thread,{:?})", thread_id);
+    log::info!("[logging] (type,node-thread-map) (node,{node_id}) (thread,{:?})", thread_id);
 }
 
 pub fn log_node_edge(src_node: &str, dest_node: &str) {
-    log::warn!("[logging] (type,node-edge) (src,{src_node}) (dest,{dest_node})");
+    log::info!("[logging] (type,node-edge) (src,{src_node}) (dest,{dest_node})");
 }
 
 pub fn log_event(task: &str, action: &str) {
     let current_thread = current().id();
     let timestamp = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos();
-    log::warn!("[logging] (type,event) (thread,{:?}) (task,{task}) (action,{action}) (timestamp,{timestamp})", current_thread);
+    log::info!("[logging] (type,event) (thread,{:?}) (task,{task}) (action,{action}) (timestamp,{timestamp})", current_thread);
 }

--- a/scripts/convert-to-parquet.py
+++ b/scripts/convert-to-parquet.py
@@ -14,6 +14,7 @@ tpch_headers = {
     "customer.tbl": ['c_custkey','c_name','c_address','c_nationkey','c_phone','c_acctbal','c_mktsegment','c_comment'],
     "orders.tbl": ['o_orderkey','o_custkey','o_orderstatus','o_totalprice','o_orderdate','o_orderpriority','o_clerk','o_shippriority','o_comment'],
     "lineitem.tbl": ['l_orderkey','l_partkey','l_suppkey','l_linenumber','l_quantity','l_extendedprice','l_discount','l_tax','l_returnflag','l_linestatus','l_shipdate','l_commitdate','l_receiptdate','l_shipinstruct','l_shipmode','l_comment'],
+    "numbertable.tbl": ['ci', 'cii', 'ciii', 'ciiii', 'ciiiii', 'ciiiiii', 'ciiiiiii', 'ciiiiiiii', 'ciiiiiiiii', 'ciiiiiiiiii', 'x'],
 }
 
 # filename: %x.tbl.1 => %x.parquet.1

--- a/scripts/deep_data_gen.py
+++ b/scripts/deep_data_gen.py
@@ -1,0 +1,56 @@
+"""
+Generate data for deep group-by query
+
+Example: python ../scripts/deep_data_gen.py 10 1000000 100 5 temp_dir
+ --> 10 group-by columns
+ --> 1M rows per partitions, 100 partitions
+ --> [0, 5] integers
+"""
+
+import numpy as np
+
+def generate_partition(rng, num_rows, num_cols, column_cardinality):
+    return rng.integers(column_cardinality, size=(num_rows, num_cols))
+
+if __name__ == '__main__':
+    import argparse
+    import os
+    parser = argparse.ArgumentParser(description='Generate deep query')
+    parser.add_argument('num_gb_columns', type=int,
+                        help='Number of group-by columns (max query depth)')
+    parser.add_argument('partition_size', type=int,
+                        help='Number of rows per partition (in millions)')
+    parser.add_argument('num_partitions', type=int,
+                        help='Number of partition')
+    parser.add_argument('column_cardinality', type=int,
+                        help='Number of distinct elements per group-by column')
+    parser.add_argument('root_dir', type=str,
+                        help='Root directory to write partitions into')
+    parser.add_argument('--seed', type=int, default=4512763,
+                        help='Randomization seed')
+    args = parser.parse_args()
+
+    # Fill in args
+    num_gb_columns = args.num_gb_columns
+    partition_size = args.partition_size
+    num_partitions = args.num_partitions
+    column_cardinality = args.column_cardinality
+    root_dir = args.root_dir
+    seed = args.seed
+
+    # Create RNG
+    rng = np.random.default_rng(seed)
+
+    # Prepare directory
+    if not os.path.exists(root_dir):
+        os.makedirs(root_dir)
+    print(f"Writing to {root_dir}")
+
+    # Generate data
+    for pidx in range(1, num_partitions + 1):
+        partition_path = os.path.join(root_dir, f"numbertable.tbl.{pidx}")
+        partition = generate_partition(rng, partition_size, num_gb_columns + 1, column_cardinality)
+        np.savetxt(partition_path, partition, fmt="%d", delimiter='|')
+        print(f"Wrote {partition_path}")
+    column_names = ["c" + "i" * idx for idx in range(num_gb_columns)] + ["x"]
+    print(f"Column names: {column_names}")

--- a/scripts/deep_query_gen.py
+++ b/scripts/deep_query_gen.py
@@ -1,0 +1,65 @@
+"""
+Generate deep group-by query
+
+Example: python ../scripts/deep_query_gen.py 10
+"""
+
+# INDENT_CHAR = '\t'
+INDENT_CHAR = '  '
+TABLE_NAME = 'numbertable'
+
+
+def indent(query):
+    return '\n'.join([INDENT_CHAR + line for line in query.split('\n')])
+
+
+def template_at_depth(depth, gb_columns, value_column, agg_cycle):
+    assert len(gb_columns) >= depth
+    agg = agg_cycle[depth % len(agg_cycle)]
+    gb = ', '.join(gb_columns[:depth])
+    query = f'SELECT {agg}(t.{value_column}) as {value_column}\n'
+    if len(gb_columns) == depth:
+        query += 'FROM {} as t\n'
+    else:
+        query += 'FROM (\n'
+        query += '{}\n'
+        query += ') AS t\n'
+    if depth > 0:
+        query += f'GROUP BY {gb}'
+    return query
+
+
+def generate_query(num_depths, gb_columns, value_column, agg_cycle):
+    query = TABLE_NAME
+    for depth in range(num_depths, -1, -1):
+        template_depth = template_at_depth(depth, gb_columns, value_column, agg_cycle)
+        query = indent(query)
+        query = template_depth.format(query)
+    return query
+
+
+if __name__ == '__main__':
+    import argparse
+    parser = argparse.ArgumentParser(description='Generate deep query')
+    parser.add_argument('num_depths', type=int,
+                        help='Query depths')
+    parser.add_argument('--gb_columns', type=str, default=None,
+                        help='List of group-by column names')
+    parser.add_argument('--value_column', type=str, default="x",
+                        help='Value column name')
+    parser.add_argument('--agg_cycle', type=list, default=['sum', 'max'],
+                        help='List of aggregates to spin through')
+    args = parser.parse_args()
+
+    # Fill in args
+    num_depths = args.num_depths
+    if args.gb_columns is None:
+        gb_columns = ["c" + "i" * idx for idx in range(num_depths)]
+    else:
+        assert len(args.gb_columns) == args.num_depths
+        gb_columns = args.gb_columns
+    value_column = args.value_column
+    agg_cycle = args.agg_cycle
+
+    # Generate query
+    print(generate_query(num_depths, gb_columns, value_column, agg_cycle))

--- a/scripts/extract_accuracy.py
+++ b/scripts/extract_accuracy.py
@@ -38,6 +38,7 @@ wake_on_dict = {
     25: [],
     26: ["l_returnflag", "l_linestatus"],
     27: [],
+    30: [],
 }
 
 pdb_on_dict = {
@@ -85,6 +86,7 @@ wake_ignore = {
     25: [],
     26: [],
     27: [],   
+    30: [],
 }
 
 pdb_ignore = {

--- a/scripts/extract_accuracy_ci.py
+++ b/scripts/extract_accuracy_ci.py
@@ -1,0 +1,158 @@
+import os
+import glob
+import re
+import json
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+from scipy.stats import describe as scipy_descibe
+
+# COUNT (fixing)
+# Q_IDX = "1c"
+# VALUE_COLUMN = "count_order"
+# VAR_COLUMN = "count_order_var"
+
+# SUM
+# Q_IDX = "6c"
+# VALUE_COLUMN = "disc_price_sum"
+# VAR_COLUMN = "disc_price_sum_var"
+
+# AVG
+Q_IDX = "14c"
+VALUE_COLUMN = "promo_revenue"
+VAR_COLUMN = "promo_revenue_var"
+
+CONFIDENCE_LEVEL = 0.95
+ALPHA = (1 / (1 - CONFIDENCE_LEVEL)) ** 0.5
+# ALPHA = 1.96
+
+def read_result(t, dirpath):
+    assert isinstance(t, int)
+    return pd.read_csv(f"{dirpath}/{t}.csv")
+
+def write_result(dirpath, results):
+    # Write in JSON
+    json_path = f"{dirpath}/results.json"
+    with open(json_path, "w") as f:
+        json.dump(results, f)
+    print(f"Written {json_path}")
+
+    # Write in text table
+    columns = []
+    cells = []
+    for key, values in results.items():
+        columns.append(key)
+        cells.append(values)
+        assert len(cells[0]) == len(values)
+    columns.append("idx")
+    cells.append(list(range(len(cells[0]))))
+    cells = np.array(cells).T
+    txt_path = f"{dirpath}/results.txt"
+    with open(txt_path, "w") as f:
+        for column in columns:
+            f.write(f"{column}\t")
+        f.write("\n")
+        for row in cells:
+            for cell in row:
+                f.write(f"{cell}\t")
+            f.write("\n")
+    print(f"Written {txt_path}")
+
+def read_all_results(dirpath, nt=None):
+    if nt is None:
+        # Read all CSVs
+        csvs = map(
+            lambda path: re.search("\/(\d+)\.csv", path),
+            glob.glob(f"{dirpath}/*.csv")
+        )
+        numbered_csvs = filter(lambda c: c is not None, csvs)
+        nt = max(map(lambda c: int(c.group(1)), numbered_csvs)) + 1
+    return [read_result(t, dirpath=dirpath) for t in range(nt)]
+
+def read_all_results_runs(dirpath, nruns):
+    return [read_all_results(f"{dirpath}/run={r}/q{Q_IDX}") for r in range(1, nruns + 1)]
+
+def check_ci(df, df_ref):
+    assert len(df) == 1
+    assert len(df_ref) == 1
+    diff = (df[VALUE_COLUMN] - df_ref[VALUE_COLUMN])[0]
+    stddev = df[VAR_COLUMN][0] ** 0.5
+    return abs(diff) <= ALPHA * stddev, \
+           ALPHA * stddev, \
+           abs(diff), \
+           abs(diff) / (ALPHA * stddev), \
+           df[VALUE_COLUMN][0], \
+           df_ref[VALUE_COLUMN][0], \
+
+def calculate_accuracy_all(q_results_runs):
+    acc = []
+    acc = []
+    for q_results in q_results_runs:
+        q_ref = q_results[-1]  # Use last result as the reference.
+        acc.append([check_ci(q_result, q_ref) for q_result in q_results])
+    acc = np.array(acc)
+    print(scipy_descibe(acc[:, 1:, 3].flatten()))
+    return {
+        "true_avg": list(acc[..., 0].mean(0)),
+        "range_avg": list(acc[..., 1].mean(0)),
+        "diff_avg": list(acc[..., 2].mean(0)),
+        "rel_avg": list(acc[..., 3].mean(0)),
+        "rel_p95": list(np.percentile(acc[..., 3], 95.0, axis=0)),
+        "rel_max": list(acc[..., 3].max(0)),
+        "x": list(acc[..., 4][0]),
+        "x_pos": list(acc[..., 4][0] + acc[..., 1][0]),
+        "x_neg": list(acc[..., 4][0] - acc[..., 1][0]),
+        # "range": acc[..., 1][1],
+        # "diff": acc[..., 2][1],
+        # "rel": acc[..., 3],
+    }
+
+if __name__ == "__main__":
+    import argparse
+    parser = argparse.ArgumentParser(description='Extract accuracy from many result')
+    parser.add_argument('dirpath', type=str,
+                        help='path to directory with qxx subdirectories')
+    parser.add_argument('ref_dirpath', type=str,
+                        help='path to directory with qxx having intermediate results')
+    parser.add_argument('num_runs', type=int,
+                        help='number of runs')
+    parser.add_argument('--answer', type=str, default=None,
+                        help='path to asnwer csv')
+    args = parser.parse_args()
+    print(f"Args: {args}")
+    if args.answer is None:
+        print(f"WARNING: using last result as the true answer")
+        answer = None
+    else:
+        print(f"Using {args.answer} as the answer sheet")
+        answer = pd.read_csv(args.answer)
+        print(answer)
+
+    # Extract result and accuracy
+    dirpath = args.dirpath
+    ref_dirpath = args.ref_dirpath
+    num_runs = args.num_runs
+    q_results_runs = read_all_results_runs(ref_dirpath, num_runs)
+    q_accuracy = calculate_accuracy_all(q_results_runs)
+
+    # Check
+    # print(q_accuracy)
+    # N, M, SZ, RS = 1, 3, 5, 1.6
+    # fig, axes = plt.subplots(ncols=M, figsize=(M * SZ * RS, N * SZ))
+    # axes[0].plot(q_accuracy["true_avg"])
+    # axes[1].plot(q_accuracy["range_avg"], label="range_avg")
+    # axes[1].plot(q_accuracy["diff_avg"], label="diff_avg")
+    # # axes[1].hist(q_accuracy["range"], label="range")
+    # # axes[1].hist(q_accuracy["diff"], label="diff")
+    # axes[1].legend()
+    # axes[2].plot(q_accuracy["rel_avg"])
+    # axes[2].plot(q_accuracy["rel_p95"])
+    # axes[2].plot(q_accuracy["rel_max"])
+    # # axes[2].hist(q_accuracy["rel"].flatten())
+    # # axes[2].set_yscale('log')
+    # plt.show()
+
+    # Write accuracy
+    write_result(dirpath, q_accuracy)
+


### PR DESCRIPTION
Calculate sum and avg CIs for Q1, Q5, Q6, Q8, Q14
- `main.rs` adds these queries with CI enabled
- `cell.rs`, `count.rs`, `scaler.rs`, `agg_accumulator.rs` propagate variances for CI
- `experiment_ci.sh` runs experiment many times
- `extract_accuracy_ci.py` measures CI accuracy

Add depth experiment scripts and wake query
- `script/deep_query_gen.py` generate depth-n SQL query
- `script/deep_data_gen.py` generate multi-column bounded-integer table for deep query experiment
- `.../q30.rs` wake query that adapts group-by nodes based on depth

Also turning off warning event logs (for tracing experiment, I think?)